### PR TITLE
Start of unit test structure, minor refactor of autoloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 .idea/.name
 .idea/codeStyleSettings.xml
 .idea/encodings.xml

--- a/Service/Autoload.php
+++ b/Service/Autoload.php
@@ -1,0 +1,25 @@
+<?php
+namespace Joindin\Service;
+
+class Autoload
+{
+    /**
+     * Autoloader for joind.in classes
+     *
+     * @param string $class Class name to load
+     *
+     * @return void
+     */
+    public static function autoload($class)
+    {
+        if (in_array('Joindin', explode('\\', $class))) {
+            // Convert namespace to directory separators
+
+            $path = str_replace('\\', '/', $class);
+
+            // Trim off Joindin
+            $path = substr($path, 8);
+            require_once(__DIR__ . '/../'.$path.'.php');
+        }
+    }
+}

--- a/tests/Model/Collection/EventTest.php
+++ b/tests/Model/Collection/EventTest.php
@@ -1,0 +1,77 @@
+<?php
+namespace test\Model\API\Collection;
+
+class EventTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests that variables are properly set when retrieve is called with no parameters
+     *
+     * @return void
+     *
+     * @test
+     */
+    public function defaultRetrievalParametersAreSet()
+    {
+        $mockEvent = $this->getMock('Joindin\Model\Collection\Event', array('apiGet'));
+        $mockEvent->expects($this->once())
+            ->method('apiGet')
+            ->with('http://api.joind.in/v2.1/events?resultsperpage=10&page=1')
+            ->will($this->returnValue(json_encode(array('events' => array(), 'meta' => array()))));
+
+        $mockEvent->retrieve();
+    }
+
+    /**
+     * Ensures that setting a limit will make the URL correctly
+     *
+     * @return void
+     *
+     * @test
+     */
+    public function retrievalWithLimitSetsParamsCorrectly()
+    {
+        $mockEvent = $this->getMock('Joindin\Model\Collection\Event', array('apiGet'));
+        $mockEvent->expects($this->once())
+            ->method('apiGet')
+            ->with('http://api.joind.in/v2.1/events?resultsperpage=75&page=1')
+            ->will($this->returnValue(json_encode(array('events' => array(), 'meta' => array()))));
+
+        $mockEvent->retrieve(75);
+    }
+
+    /**
+     * Ensures that asking for a different page sets params correctly
+     *
+     * @return void
+     *
+     * @test
+     */
+    public function retrievalWithPageValueSetsParamsCorrectly()
+    {
+        $mockEvent = $this->getMock('Joindin\Model\Collection\Event', array('apiGet'));
+        $mockEvent->expects($this->once())
+            ->method('apiGet')
+            ->with('http://api.joind.in/v2.1/events?resultsperpage=32&page=6')
+            ->will($this->returnValue(json_encode(array('events' => array(), 'meta' => array()))));
+
+        $mockEvent->retrieve(32, 6);
+    }
+
+    /**
+     * Ensures that setting all 3 params sets everything correctly
+     *
+     * @return void
+     *
+     * @test
+     */
+    public function retrievalWithFilterSetsAllParamsCorrectly()
+    {
+        $mockEvent = $this->getMock('Joindin\Model\Collection\Event', array('apiGet'));
+        $mockEvent->expects($this->once())
+            ->method('apiGet')
+            ->with('http://api.joind.in/v2.1/events?resultsperpage=16&page=3&filter=samoflange')
+            ->will($this->returnValue(json_encode(array('events' => array(), 'meta' => array()))));
+
+        $mockEvent->retrieve(16, 3, 'samoflange');
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+require_once __DIR__ . '/../Service/Autoload.php';
+
+spl_autoload_register('Joindin\Service\Autoload::autoload');
+

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,11 @@
+<phpunit bootstrap="./bootstrap.php">
+    <testsuite name="Joind.in responsive Test Suite">
+        <directory>.</directory>
+    </testsuite>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhiteList="true">
+            <directory suffix=".php">.</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/web/index.php
+++ b/web/index.php
@@ -1,7 +1,9 @@
 <?php
 namespace Joindin;
 
-spl_autoload_register('Joindin\autoload');
+require_once '../Service/Autoload.php';
+
+spl_autoload_register('Joindin\Service\autoload::autoload');
 
 session_cache_limiter(false);
 session_start();
@@ -31,12 +33,3 @@ new Controller\Event($app);
 
 // execute application
 $app->run();
-
-function autoload($class)
-{
-    if (in_array('Joindin', explode('\\', $class))) {
-        $path = str_replace('\\', '/', $class);
-        $path = substr($path, 8);
-        require_once('../'.$path.'.php');
-    }
-}


### PR DESCRIPTION
Started a structure to allow for unit tests for the new project. Minor refactoring of the autoloader into a class so it can be used by the bootstrap file for phpunit.

Unit tests can be run with "phpunit" in the tests directory. Right now the only test is for the event collection class and it's only for the url building. The actual calls are mocked right now so it is a real unit test.
