### PR TITLE
Remove /view segment from URL.

### DIFF
--- a/app/Joindin/Controller/Event.php
+++ b/app/Joindin/Controller/Event.php
@@ -8,8 +8,8 @@ class Event extends Base
     protected function defineRoutes(\Slim $app)
     {
         $app->get('/event', array($this, 'index'));
-        $app->get('/event/view/:id', array($this, 'details'));
-        $app->get('/event/view/:id/map', array($this, 'map'));
+        $app->get('/event/:id', array($this, 'details'));
+        $app->get('/event/:id/map', array($this, 'map'));
         $app->get('/event/:id/schedule', array($this, 'schedule'));
     }
 

--- a/app/Joindin/Model/Event.php
+++ b/app/Joindin/Model/Event.php
@@ -22,7 +22,7 @@ class Event
 
     public function getUrl()
     {
-        return '/event/view/'.$this->getSlug();
+        return '/event/'.$this->getSlug();
     }
 
     public function getIcon()

--- a/app/templates/Event/_common/event_header.html.twig
+++ b/app/templates/Event/_common/event_header.html.twig
@@ -18,12 +18,6 @@
     <ul>
         <li><a href="{{ event.getUrl }}">Details</a></li>
         <li><a href="{{ event.getUrl }}/map">Map</a></li>
-        <!-- The schedule URL uses the new URL without /view/, until we fix
-             all event page URLs to be consistant, I've put in a temporary
-             fix for now. It can probably be removed and the following line
-             uncommented out once the fix has been completed
-         -->
-        <!--<li><a href="{{ event.getUrl }}/schedule">Schedule</a></li>-->
-        <li><a href="/event/{{ event.getSlug }}/schedule">Schedule</a></li>
+        <li><a href="{{ event.getUrl }}/schedule">Schedule</a></li>
     </ul>
 </nav>


### PR DESCRIPTION
The URL scheme for events just needs to be /event/{slug}, not /event/view/{slug}.
