### PR TITLE
Remove Google Analytics key from config.php.dist

### DIFF
--- a/config/config.php.dist
+++ b/config/config.php.dist
@@ -4,7 +4,7 @@ $config = array(
         'mode' => 'development',
         'custom' => array(
             'apiUrl' => 'https://api.joind.in',
-            'googleAnalyticsId' => 'UA-246789-3'
+            'googleAnalyticsId' => ''
         ),
         'oauth' => array(
             'client_id' => 'web2',


### PR DESCRIPTION
It shouldn't be in the config dist file as it's only required in live's
config.php.
