### PR TITLE
diplay names of commenting users

### DIFF
--- a/app/templates/_common/comment.html.twig
+++ b/app/templates/_common/comment.html.twig
@@ -1,5 +1,4 @@
 {# This template should work for both event and talk comments #}
-{#{{ dump(comment) }}#}
 
 <li class="comment" id="comment-{{ hash(comment.comment_uri)|slice(1,7) }}">
     {% if comment.rating %} {% include '_common/rating.html.twig' with {'rating': comment.rating} %} {% endif %}
@@ -7,9 +6,9 @@
         {{ comment.comment }}
     </div>
     <div class="info">
-        by {% if comment.getUserDisplayName %}
-            <a href="{{ urlForSpeaker(comment.getUserDisplayName) }}" class="speaker-url">
-                {{ comment.getUserDisplayName }}
+        by {% if comment.user_display_name %}
+            <a href="{{ urlForSpeaker(comment.user_display_name) }}" class="speaker-url">
+                {{ comment.user_display_name }}
             </a>
         {% else %}Anonymous{% endif %}
         at {{ comment.created_date|date('H:i \\o\\n j M Y') }}


### PR DESCRIPTION
This fixes the bug where all the names look anonymous on event comments BUT it directly accesses a properly of the object, rather that using a getter.  In this context, the comment is a stdClass so it doesn't pick up any specific Comment Model functionality.  This improves things in the immediate short term, but probably isn't the end of the story.
