### PR TITLE
Fix usage of the event api

### DIFF
--- a/app/Joindin/Controller/Event.php
+++ b/app/Joindin/Controller/Event.php
@@ -162,8 +162,7 @@ class Event extends Base
         $request = $this->application->request();
         $comment = $request->post('comment');
 
-        $keyPrefix = $this->cfg['redis']['keyPrefix'];
-        $apiEvent = new EventApi($this->cfg, $this->accessToken, new \Joindin\Model\Db\Event($keyPrefix));
+        $apiEvent = $this->getEventApi();
         $event = $apiEvent->getByFriendlyUrl($friendly_name);
         if ($event) {
             $apiEvent->addComment($event, $comment);


### PR DESCRIPTION
Fix usage of the event api in the add comment method, it was causing an error due to the Db constructor wanting a cache object rather than the keyPrefix string.
