### PR TITLE
JOINDIN-443: Add comment source to template

### DIFF
--- a/app/src/Event/EventCommentEntity.php
+++ b/app/src/Event/EventCommentEntity.php
@@ -17,16 +17,37 @@ class EventCommentEntity
 
     public function getUserDisplayName()
     {
-        return $this->data->user_display_name;
+        if (isset($this->data->user_display_name)) {
+            return $this->data->user_display_name;
+        } else {
+            return null;
+        }
     }
 
     public function getCommentDate()
     {
-        return $this->data->created_date;
+        if (isset($this->data->created_date)) {
+            return $this->data->created_date;
+        } else {
+            return null;
+        }
     }
 
     public function getComment()
     {
-        return $this->data->comment;
+        if (isset($this->data->comment)) {
+            return $this->data->comment;
+        } else {
+            return null;
+        }
+    }
+
+    public function getCommentSource()
+    {
+        if (isset($this->data->source)) {
+            return $this->data->source;
+        } else {
+            return null;
+        }
     }
 }

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -61,7 +61,7 @@ class EventController extends BaseController
                     array("stub" => $event->getStub()
                 ));
 
-            $comments = $eventApi->getComments($event->getCommentsUri());
+            $comments = $eventApi->getComments($event->getCommentsUri(), true);
             echo $this->render(
                 'Event/details.html.twig',
                 array(

--- a/app/templates/_common/comment.html.twig
+++ b/app/templates/_common/comment.html.twig
@@ -15,7 +15,7 @@
 
             <p class="meta">
                 at {{ comment.getCommentDate|date('H:i \\o\\n j M Y') }}
-                {% if comment.source %}via {{ comment.source }}{% endif %}
+                {% if comment.getCommentSource is not null %}<br />via {{ comment.getCommentSource }}{% endif %}
             </p>
         </section>
         <section>

--- a/tests/Event/EventCommentEntityTest.php
+++ b/tests/Event/EventCommentEntityTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace Tests\Event;
+
+use Event\EventCommentEntity;
+use stdClass;
+
+class EventCommentEntityTest extends \PHPUnit_Framework_TestCase
+{
+    private $commentData;
+
+    public function setUp()
+    {
+        $this->commentData = new stdClass();
+        $this->commentData->rating              = 5;
+        $this->commentData->comment             = "Test event comment text";
+        $this->commentData->user_display_name   = "Test comment display name";
+        $this->commentData->talk_title          = "Test talk title";
+        $this->commentData->created_date        = "2014-03-02T08:43:44+01:00";
+        $this->commentData->uri                 = "Test comment uri";
+        $this->commentData->verbose_uri         = "Test comment verbose uri";
+        $this->commentData->talk_uri            = "Test talk uri";
+        $this->commentData->talk_comments_uri   = "Test comments uri";
+        $this->commentData->user_uri            = "Test user uri";
+        $this->commentData->source              = "Test comment source";
+
+    }
+
+    public function testBasicCommentsData()
+    {
+        $comment = new EventCommentEntity($this->commentData);
+
+        $this->assertEquals(
+            $comment->getUserDisplayName(),
+            "Test comment display name"
+        );
+
+        $this->assertEquals(
+            $comment->getCommentDate(),
+            "2014-03-02T08:43:44+01:00"
+        );
+
+        $this->assertEquals(
+            $comment->getComment(),
+            "Test event comment text"
+        );
+
+        $this->assertEquals(
+            $comment->getCommentSource(),
+            "Test comment source"
+        );
+
+    }
+
+    public function testNonExistentTestDataDoesntBreak()
+    {
+        $comment = new EventCommentEntity(new stdClass());
+
+        $this->assertNull($comment->getUserDisplayName());
+        $this->assertNull($comment->getCommentDate());
+        $this->assertNull($comment->getComment());
+        $this->assertNull($comment->getCommentSource());
+    }
+
+}


### PR DESCRIPTION
Adds the comment source to the template via a new entity method.
Adds in unit tests to cover the EvenCommentEntity methods.
Updates the existing EventCommentEntity methods to return null if not set.
