### PR TITLE
JOINDIN-441 Check to see if the comment are enabled for a talk

### DIFF
--- a/app/src/Event/EventEntity.php
+++ b/app/src/Event/EventEntity.php
@@ -205,4 +205,12 @@ class EventEntity
         return $this->data->stub;
     }
 
+    public function getCommentsEnabled()
+    {
+        if (!isset($this->data->comments_enabled)) {
+            return null;
+        }
+
+        return $this->data->comments_enabled;
+    }
 }

--- a/app/templates/Event/details.html.twig
+++ b/app/templates/Event/details.html.twig
@@ -15,7 +15,7 @@
             </ul>
         {% endif %}
 
-        {% if user %}
+        {% if user and event.getCommentsEnabled %}
             <h2>Write a comment</h2>
             <form id="add-comment" method="POST" action="{{ urlFor('event-add-comment', {'friendly_name': event.getUrlFriendlyName}) }}">
             <div>
@@ -26,7 +26,9 @@
                 <input type="submit" value="Submit comment">
             </div>
             </form>
-        {% else %}
+        {% endif %}
+
+        {% if user == null %}
             <a href="{{ urlFor('user-login') }}">Login</a> to write a comment
         {% endif %}
     </div>

--- a/tests/Event/EventEntityTest.php
+++ b/tests/Event/EventEntityTest.php
@@ -13,26 +13,27 @@ class EventEntityTest extends \PHPUnit_Framework_TestCase
         // Not used at the moment, but it's here for future use when we
         // want to provide data to the class
         $this->eventData = new stdClass($data);
-		$this->eventData->name                 = "Test event name";
-		$this->eventData->icon                 = "Test event icon";
-		$this->eventData->start_date           = "Test event start date";
-		$this->eventData->end_date             = "Test event end date";
-		$this->eventData->location             = "Test event location";
-		$this->eventData->description          = "Test event description";
-		$this->eventData->tags                 = "Test event tags";
-		$this->eventData->latitude             = "Test event latitude";
-		$this->eventData->longitude            = "Test event longitude";
-		$this->eventData->href                 = "Test event href";
-		$this->eventData->attendee_count       = "Test event attendee count";
-		$this->eventData->event_comments_count = "Test event event comments count";
-		$this->eventData->comments_uri         = "Test event comments uri";
-		$this->eventData->talks_uri            = "Test event talks uri";
-		$this->eventData->uri                  = "Test event uri";
-		$this->eventData->verbose_uri          = "Test event verbose uri";
-		$this->eventData->attending            = "Test event attending";
+        $this->eventData->name                 = "Test event name";
+        $this->eventData->icon                 = "Test event icon";
+        $this->eventData->start_date           = "Test event start date";
+        $this->eventData->end_date             = "Test event end date";
+        $this->eventData->location             = "Test event location";
+        $this->eventData->description          = "Test event description";
+        $this->eventData->tags                 = "Test event tags";
+        $this->eventData->latitude             = "Test event latitude";
+        $this->eventData->longitude            = "Test event longitude";
+        $this->eventData->href                 = "Test event href";
+        $this->eventData->attendee_count       = "Test event attendee count";
+        $this->eventData->event_comments_count = "Test event event comments count";
+        $this->eventData->comments_uri         = "Test event comments uri";
+        $this->eventData->talks_uri            = "Test event talks uri";
+        $this->eventData->uri                  = "Test event uri";
+        $this->eventData->verbose_uri          = "Test event verbose uri";
+        $this->eventData->attending            = "Test event attending";
         $this->eventData->attending_uri        = "Test event attending uri";
-		$this->eventData->url_friendly_name    = "Test event url friendly name";
-		$this->eventData->stub                 = "Test event stub";
+        $this->eventData->url_friendly_name    = "Test event url friendly name";
+        $this->eventData->stub                 = "Test event stub";
+        $this->eventData->comments_enabled     = "Test that comments are enabled";
     }
 
     public function testBasicEventData()
@@ -138,6 +139,11 @@ class EventEntityTest extends \PHPUnit_Framework_TestCase
             $event->getApiUriToMarkAsAttending(),
             "Test event attending uri"
         );
+
+        $this->assertEquals(
+            $event->getCommentsEnabled(),
+            "Test that comments are enabled"
+        );
     }
 
     public function testNonExistentTestDataDoesntBreak()
@@ -164,5 +170,6 @@ class EventEntityTest extends \PHPUnit_Framework_TestCase
         $event->isAttending();
         $event->getUrlFriendlyName();
         $event->getStub();
+        $event->getCommentsEnabled();
     }
 }


### PR DESCRIPTION
If the comments are enabled then we can show the comment form
for the talk, otherwise we want to hide it.

Just need to implement a similar check in the api before saving.
