### PR TITLE
Code coverage shows test folder and not app

### DIFF
--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -13,7 +13,7 @@
 
     <filter>
         <whitelist processUncoveredFilesFromWhiteList="true">
-            <directory suffix=".php">.</directory>
+            <directory suffix=".php">../app</directory>
         </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
The whitelisting of the code coverage was set to only show the coverage of
the test folder itself; which unsurpisingly was almost 100%. By changing the
whitelist to point to the app folder in the root of the project we get an
accurate representation of the code coverage.

After running the unit tests one can see the code coverage in the
build/coverage folder; by opening the index.html you can browse through all
files and determine what needs to be covered.
