### PR TITLE
Remove superfluous and misleading echo's

### DIFF
--- a/app/src/Application/ApplicationController.php
+++ b/app/src/Application/ApplicationController.php
@@ -28,7 +28,7 @@ class ApplicationController extends BaseController
         $event_collection = new EventApi($this->cfg, $this->accessToken, new EventDb($cache));
         $hot_events = $event_collection->getCollection($perPage, $start, 'hot');
 
-        echo $this->render(
+        $this->render(
             'Application/index.html.twig',
             array(
                 'events' => $hot_events,
@@ -39,7 +39,7 @@ class ApplicationController extends BaseController
 
     public function apps()
     {
-        echo $this->render('Application/apps.html.twig');
+        $this->render('Application/apps.html.twig');
     }
 
     /**
@@ -47,8 +47,6 @@ class ApplicationController extends BaseController
      */
     public function about()
     {
-        echo $this->render(
-            'Application/about.html.twig'
-        );
+        $this->render('Application/about.html.twig');
     }
 }

--- a/app/src/Application/BaseController.php
+++ b/app/src/Application/BaseController.php
@@ -31,7 +31,7 @@ abstract class BaseController
     protected function render($template, $data = array(), $status = null)
     {
         try {
-            echo $this->application->render($template, $data, $status);
+            $this->application->render($template, $data, $status);
         } catch (Twig_Error_Runtime $e) {
             $this->application->render(
                 'Error/app_load_error.html.twig',

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -46,7 +46,7 @@ class EventController extends BaseController
             'upcoming'
         );
 
-        echo $this->render(
+        $this->render(
             'Event/index.html.twig',
             array(
                 'page' => $page,
@@ -67,7 +67,7 @@ class EventController extends BaseController
                 ));
 
             $comments = $eventApi->getComments($event->getCommentsUri(), true);
-            echo $this->render(
+            $this->render(
                 'Event/details.html.twig',
                 array(
                     'event' => $event,
@@ -90,7 +90,7 @@ class EventController extends BaseController
         $event = $eventApi->getByFriendlyUrl($friendly_name);
 
         if($event) {
-            echo $this->render(
+            $this->render(
                 'Event/map.html.twig',
                 array(
                     'event' => $event
@@ -116,7 +116,7 @@ class EventController extends BaseController
 
             $schedule = $scheduler->getScheduleData($event);
 
-            echo $this->render(
+            $this->render(
                 'Event/schedule.html.twig',
                 array(
                     'event' => $event,

--- a/app/src/Search/SearchController.php
+++ b/app/src/Search/SearchController.php
@@ -60,7 +60,7 @@ class SearchController extends BaseController
             $events = $event_collection->getEventCollection($keyword, $perPage, $start);
         }
 
-        echo $this->render(
+        $this->render(
             'Event/search.html.twig',
             array(
                 'events'    => $events,

--- a/app/src/Talk/TalkController.php
+++ b/app/src/Talk/TalkController.php
@@ -27,7 +27,7 @@ class TalkController extends BaseController
         $event = $eventApi->getByFriendlyUrl($eventSlug);
 
         if (!$event) {
-            echo $this->render(
+            $this->render(
                 'Event/error_404.html.twig',
                 array(
                     'message' => 'Event was not retrieved, perhaps the slug is invalid?',
@@ -47,7 +47,7 @@ class TalkController extends BaseController
 
         $comments = $talkApi->getComments($talk->getCommentUri(), true);
 
-        echo $this->render(
+        $this->render(
             'Talk/index.html.twig',
             array(
                 'talk' => $talk,
@@ -107,6 +107,5 @@ class TalkController extends BaseController
         $this->application->flash('message', 'Thank you for your comment.');
         $url .= '#add-comment';
         $this->application->redirect($url);
-
     }
 }

--- a/app/src/User/UserController.php
+++ b/app/src/User/UserController.php
@@ -9,7 +9,7 @@ class UserController extends BaseController
     /**
      * Routes implemented by this class
      *
-     * @param  Slim   $app Slim application instance
+     * @param \Slim $app Slim application instance
      *
      * @return void
      */
@@ -63,12 +63,7 @@ class UserController extends BaseController
             }
         }
 
-        echo $this->render(
-            'User/login.html.twig',
-            array(
-                'error' => $error,
-            )
-        );
+        $this->render('User/login.html.twig', array('error' => $error));
     }
 
     /**


### PR DESCRIPTION
In the each call to render seems to be prefixed with the echo keyword
but the render method does not return data; it adds the rendered output
to the view cache / output buffer so that it can be echo'd later
by Slim itself.

In this commit I remove all superfluous echo's since it may mislead
people into thinking that the echo's actually have a function and use
it to circumvent the view mechanism of Slim or have unpredictable bugs.
