### PR TITLE
Talk page improvements

### DIFF
--- a/app/src/Talk/TalkEntity.php
+++ b/app/src/Talk/TalkEntity.php
@@ -125,4 +125,14 @@ class TalkEntity
 
         return $this->data->comments_uri;
     }
+
+    public function getSlidesLink()
+    {
+        return $this->data->slides_link;
+    }
+
+    public function getLanguage()
+    {
+        return $this->data->language;
+    }
 }

--- a/app/templates/Talk/index.html.twig
+++ b/app/templates/Talk/index.html.twig
@@ -16,22 +16,24 @@
 {% block body %}
     {% include 'Event/_common/event_header.html.twig' %}
     <section>
-        <h2>
-            {% if talk.getType != 'Talk' %}
-                <span class="talk-type-label {{ talk.getTypeClass }}">{{ talk.getType }}</span>
-            {% endif %}
-
+        <h3>
             {{ talk.getTitle }}
-
-            {% if talk.getSpeakers %}
-                &mdash;
-                {% for speaker in talk.getSpeakers %}
-                    {{ speaker.speaker_name }}{% if not speaker.last and not speaker.first %}, {% endif %}
-                {% endfor %}
+            {% if talk.getType != 'Talk' %}
+                <span class="label talk-type-label {{ talk.getTypeClass }}">{{ talk.getType }}</span>
             {% endif %}
-        </h2>
-        <p>
-        </p>
+        </h3>
+        {% if talk.getSpeakers %}
+            <h4>
+                {% for speaker in talk.getSpeakers %}
+                    {{ speaker.speaker_name }}{% if not loop.last %}, {% endif %}
+                {% endfor %}
+                <small>{{ talk.startDate|date('d F Y \\a\\t H:i') }} &mdash; {{ talk.language }}</small>
+            </h4>
+        {% endif %}
+
+        <ul class="list-inline">
+            {% if talk.slidesLink is not empty %}<li><a href="{{ talk.slidesLink }}">View Slides</a></li>{% endif %}
+        </ul>
 
         <p>{{ talk.getDescription | nl2br }}</p>
     </section>

--- a/web/css/joindin.css
+++ b/web/css/joindin.css
@@ -17,13 +17,8 @@ nav.navbar a.navbar-brand img {
 h1 {
     border-bottom: 1px solid #d7dcdf;
     color: #f90;
-    font-size: 24px;
     font-weight: normal;
     margin-bottom: 16px;
-}
-
-h2 {
-    font-size: 20px;
 }
 
 aside {


### PR DESCRIPTION
Tweaked a few things in the talk page and added a few new features:
- Removed h1/h2 override that could trigger issues with bootstrap and also made h3 larger then h2
- Changed regular design of the talk title and information
- Added slides link along with date and language
