### PR TITLE
Talk page: date fix

### DIFF
--- a/app/templates/Talk/index.html.twig
+++ b/app/templates/Talk/index.html.twig
@@ -27,7 +27,7 @@
                 {% for speaker in talk.getSpeakers %}
                     {{ speaker.speaker_name }}{% if not loop.last %}, {% endif %}
                 {% endfor %}
-                <small>{{ talk.startDate|date('d F Y \\a\\t H:i') }} &mdash; {{ talk.language }}</small>
+                <small>{{ talk.getStartDateTime()|date('d F Y \\a\\t H:i') }} &mdash; {{ talk.language }}</small>
             </h4>
         {% endif %}
 


### PR DESCRIPTION
I was using the wrong property to get the date of the talk, leading to all talks using today's date.
Fixed that, sorry about it.
