### PR TITLE
Disable debug when mode is set to live.

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -30,6 +30,10 @@ $app = new \Slim\Slim(
     )
 );
 
+$app->configureMode('live', function () use ($app) {
+    $app->config('debug', 0);
+});
+
 $app->configureMode('development', function () use ($app) {
     error_reporting(-1);
     ini_set('display_errors', 1);


### PR DESCRIPTION
When we're in live mode, we should disable debug so that we don't display pretty exceptions with stack traces.

JOINDIN-472 #close Fixed.
