### PR TITLE
Set debug to 1 by default in the config.php.dist

### DIFF
--- a/config/config.php.dist
+++ b/config/config.php.dist
@@ -2,6 +2,7 @@
 $config = array(
     'slim' => array(
         'mode' => 'development',
+        'debug' => 1,
         'custom' => array(
             'redisKeyPrefix' => 'dev-',
             'apiUrl' => 'https://api.joind.in',


### PR DESCRIPTION
Mostly to document that the setting exists… Should be 0 on a production site.
