### PR TITLE
JOINDIN-428 added canonical and shortlink url

### DIFF
--- a/app/templates/Event/details.html.twig
+++ b/app/templates/Event/details.html.twig
@@ -53,3 +53,8 @@
     {% endif %}
 {% endblock %}
 
+{% block extra_meta %}
+    {{ parent() }}
+    <link rel="canonical" href="{{ urlFor('event-detail', {"friendly_name": event.getUrlFriendlyName}) }}" />
+    {% if event.getStub %}<link rel="shortlink" href="{{ shortUrlForEvent(event.getStub) }}" />{% endif %}
+{% endblock %}

--- a/app/templates/layout.html.twig
+++ b/app/templates/layout.html.twig
@@ -5,6 +5,7 @@
     <title>{% block title %}Joind.in{% endblock %}</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% block extra_meta %}{% endblock %}
     <link href="/css/bootstrap.min.css" rel="stylesheet">
     <link href="/css/bootstrap-theme.min.css" rel="stylesheet">
     <link href="/css/font-awesome-custom.css" rel="stylesheet">


### PR DESCRIPTION
Added a new block extra_meta to layout.html.twig and used that block on the details page to add the canonical and shortlink urls.
