### PR TITLE
Make both Twig caches clear until I figure out a better way to differentiate

### DIFF
--- a/scripts/jenkinslaunch.sh
+++ b/scripts/jenkinslaunch.sh
@@ -36,6 +36,7 @@ mkdir -p $TARGET \
 && ln -s $TARGETBASE/config.php $TARGET/config/config.php \
 && ln -s $TARGET $TARGETBASE/www.new \
 && mv -Tf $TARGETBASE/www.new $TARGETBASE/www \
-&& rm -rf /tmp/joindin-twig-cache/live
+&& rm -rf /tmp/joindin-twig-cache/live \
+&& rm -rf /tmp/joindin-twig-cache/test
 "
 


### PR DESCRIPTION
This is a temporary situation, but prevents the need to login to the live server when launching test.
