### PR TITLE
Show talk title in events recent talk comments even when comment is empty

### DIFF
--- a/app/templates/_common/comment.html.twig
+++ b/app/templates/_common/comment.html.twig
@@ -35,16 +35,17 @@
             </div>
         </div>
     </div>
-    {% if comment.comment is not empty %}
-        <div class="panel-body">
+    <div class="panel-body">
+        {% if comment.comment is not empty %}
             <p>
                 {{ comment.comment | nl2br }}
             </p>
-            {% if showTalkTitle and talkLink %}
+        {% endif %}
+
+        {% if showTalkTitle and talkLink %}
             <div class="commented-on">
                 on <a href="{{ talkLink }}">{{ comment.getTalkTitle }}</a>
             </div>
-            {% endif %}
-        </div>
-    {% endif %}
+        {% endif %}
+    </div>
 </div>


### PR DESCRIPTION
Move talk title link outside `if comment.comment is not empty` statement so that the talk title will be shown even if the comment is empty.
Without talk titles the comments have no context in the events talk comments listing,. There could be multiple comments (or more like ratings when without actual comment) from the same user and without the talk title you have no idea what talk the ratings belong to.
Example: https://m.joind.in/event/php-north-west-2014/talk-comments?page=3
