### PR TITLE
JOINDIN-507 No plural for one comment

### DIFF
--- a/app/templates/Event/_common/summary.html.twig
+++ b/app/templates/Event/_common/summary.html.twig
@@ -39,7 +39,12 @@ set eventUrl = urlFor(
                 |
 
                 <a href="{{ eventUrl }}#comments">
-                    {{ event.getCommentsCount}} comments
+                    {{ event.getCommentsCount}}
+                    {% if event.getCommentsCount == 1 %}
+                        comment
+                    {% else %}
+                        comments
+                    {% endif %}
                 </a>
 
                 {% include 'Event/_common/attending_string.html.twig' %}


### PR DESCRIPTION
In an events list, show comment link plural correctly according to comment count.
Fixes https://joindin.jira.com/browse/JOINDIN-507
