### PR TITLE
JOINDIN-508 highlight selected comment "deep link"

### DIFF
--- a/web/css/joindin.css
+++ b/web/css/joindin.css
@@ -279,33 +279,3 @@ form ul.errors {
   height: 60px;
   visibility: hidden;
 }
-
-/* flash effect to highlight selected comment */
-.flash {
-    -moz-animation: flash 4s ease-out;
-    -moz-animation-iteration-count: 1;
-
-    -webkit-animation: flash 4s ease-out;
-    -webkit-animation-iteration-count: 1;
-
-    -ms-animation: flash 4s ease-out;
-    -ms-animation-iteration-count: 1;
-}
-
-@-webkit-keyframes flash {
-    0% { background-color: none; }
-    50% { background-color: #fbf8b2; }
-    100% { background-color: none; }
-}
-
-@-moz-keyframes flash {
-    0% { background-color: none; }
-    50% { background-color: #fbf8b2; }
-    100% { background-color: none; }
-}
-
-@-ms-keyframes flash {
-    0% { background-color: none; }
-    50% { background-color: #fbf8b2; }
-    100% { background-color: none; }
-}

--- a/web/js/joindin.js
+++ b/web/js/joindin.js
@@ -116,15 +116,22 @@ $(function(){
 
     /**
      * Find panel element inside the comment container and change the bootstrap panel style
-     * from "default" (gray) to "info" (light blue) + add "flash" class to highlight the given comment.
+     * from "default" (gray) to "info" (light blue) to highlight the given comment.
      *
      * @param elementId
      */
     function highlightComment(elementId) {
+        // First remove highlight style from any previously highlighted comment
+        $('.comment-highlight')
+            .removeClass('panel-info')
+            .addClass('panel-default')
+            .removeClass('comment-highlight');
+
+        // Then add highlight style to the given comment
         $('#' + elementId)
             .find('.panel')
             .removeClass('panel-default')
             .addClass('panel-info')
-            .addClass('flash');
+            .addClass('comment-highlight');
     }
 });


### PR DESCRIPTION
Hightlight selected comment with a flash effect (using CSS) and change the bootstrap panel style
Fixes https://joindin.jira.com/browse/JOINDIN-508

Currently "flashes" the comment background to yellow and back and also changes the comment bootstrap panel style from default gray to light blue. If this is too much, it could just be either one of those effects.
