### PR TITLE
A collection of minor tidy-ups

### DIFF
--- a/app/src/Application/ApplicationController.php
+++ b/app/src/Application/ApplicationController.php
@@ -22,15 +22,15 @@ class ApplicationController extends BaseController
         $perPage = 6;
         $start = ($page -1) * $perPage;
 
-        $event_collection = $this->getEventApi();
-        $hot_events = $event_collection->getFilteredCollection($perPage, $start, 'hot');
-        $cfp_events = $event_collection->getFilteredCollection(10, 0, 'cfp', true);
+        $eventApi = $this->getEventApi();
+        $hotEvents = $eventApi->getFilteredCollection($perPage, $start, 'hot');
+        $cfpEvents = $eventApi->getFilteredCollection(10, 0, 'cfp', true);
 
         $this->render(
             'Application/index.html.twig',
             array(
-                'events' => $hot_events,
-                'cfp_events' => $cfp_events,
+                'events' => $hotEvents,
+                'cfp_events' => $cfpEvents,
                 'page' => $page,
             )
         );

--- a/app/src/Application/ApplicationController.php
+++ b/app/src/Application/ApplicationController.php
@@ -26,8 +26,8 @@ class ApplicationController extends BaseController
 
         $cache = new CacheService($keyPrefix);
         $event_collection = new EventApi($this->cfg, $this->accessToken, new EventDb($cache));
-        $hot_events = $event_collection->getCollection($perPage, $start, 'hot');
-        $cfp_events = $event_collection->getCollection(10, 0, 'cfp', true);
+        $hot_events = $event_collection->getFilteredCollection($perPage, $start, 'hot');
+        $cfp_events = $event_collection->getFilteredCollection(10, 0, 'cfp', true);
 
         $this->render(
             'Application/index.html.twig',

--- a/app/src/Application/ApplicationController.php
+++ b/app/src/Application/ApplicationController.php
@@ -22,10 +22,7 @@ class ApplicationController extends BaseController
         $perPage = 6;
         $start = ($page -1) * $perPage;
 
-        $keyPrefix = $this->cfg['redisKeyPrefix'];
-
-        $cache = new CacheService($keyPrefix);
-        $event_collection = new EventApi($this->cfg, $this->accessToken, new EventDb($cache));
+        $event_collection = $this->getEventApi();
         $hot_events = $event_collection->getFilteredCollection($perPage, $start, 'hot');
         $cfp_events = $event_collection->getFilteredCollection(10, 0, 'cfp', true);
 
@@ -50,5 +47,23 @@ class ApplicationController extends BaseController
     public function about()
     {
         $this->render('Application/about.html.twig');
+    }
+
+    /**
+     * @return CacheService
+     */
+    private function getCache()
+    {
+        $keyPrefix = $this->cfg['redisKeyPrefix'];
+        return new CacheService($keyPrefix);
+    }
+
+    /**
+     * @return EventApi
+     */
+    private function getEventApi()
+    {
+        $eventDb = new EventDb($this->getCache());
+        return new EventApi($this->cfg, $this->accessToken, $eventDb);
     }
 }

--- a/app/src/Application/ApplicationController.php
+++ b/app/src/Application/ApplicationController.php
@@ -23,8 +23,8 @@ class ApplicationController extends BaseController
         $start = ($page -1) * $perPage;
 
         $eventApi = $this->getEventApi();
-        $hotEvents = $eventApi->getFilteredCollection($perPage, $start, 'hot');
-        $cfpEvents = $eventApi->getFilteredCollection(10, 0, 'cfp', true);
+        $hotEvents = $eventApi->getEvents($perPage, $start, 'hot');
+        $cfpEvents = $eventApi->getEvents(10, 0, 'cfp', true);
 
         $this->render(
             'Application/index.html.twig',

--- a/app/src/Event/EventApi.php
+++ b/app/src/Event/EventApi.php
@@ -18,7 +18,7 @@ class EventApi extends BaseApi
     }
 
     /**
-     * Get the latest events
+     * Get a paginated list of events, optionally applying a filter
      *
      * @param integer $limit       Number of events to get per page
      * @param integer $start       Start value for pagination
@@ -28,7 +28,7 @@ class EventApi extends BaseApi
      *
      * @return EventEntity model
      */
-    public function getCollection($limit = 10, $start = 1, $filter = null, $verbose = false, array $queryParams = [])
+    public function getFilteredCollection($limit = 10, $start = 1, $filter = null, $verbose = false, array $queryParams = [])
     {
         $url = $this->baseApiUrl . '/v2.1/events';
         $queryParams['resultsperpage'] = $limit;

--- a/app/src/Event/EventApi.php
+++ b/app/src/Event/EventApi.php
@@ -42,7 +42,7 @@ class EventApi extends BaseApi
             $queryParams['verbose'] = 'yes';
         }
 
-        return $this->queryEvents($url, $queryParams);
+        return $this->getCollection($url, $queryParams);
     }
 
     /**
@@ -204,7 +204,7 @@ class EventApi extends BaseApi
 
         // if successful, return event entity represented by the URL in the Location header
         if ($status == 201) {
-            $response = $this->queryEvents($headers['location']);
+            $response = $this->getCollection($headers['location']);
             return current($response['events']);
         }
         if ($status == 202) {
@@ -225,9 +225,9 @@ class EventApi extends BaseApi
      *
      * @return array
      */
-    public function queryEvents($url, array $queryParams = [])
+    public function getCollection($uri, array $queryParams = array())
     {
-        $events = (array)json_decode($this->apiGet($url, $queryParams));
+        $events = (array)json_decode($this->apiGet($uri, $queryParams));
         $meta   = array_pop($events);
 
         $collectionData = array();

--- a/app/src/Event/EventApi.php
+++ b/app/src/Event/EventApi.php
@@ -231,9 +231,9 @@ class EventApi extends BaseApi
         $meta   = array_pop($events);
 
         $collectionData = array();
-        foreach ($events['events'] as $event) {
-            $thisEvent = new EventEntity($event);
-            $collectionData['events'][] = $thisEvent;
+        foreach ($events['events'] as $item) {
+            $event = new EventEntity($item);
+            $collectionData['events'][] = $event;
 
             // save the URL so we can look up by it
             $this->eventDb->save($event);

--- a/app/src/Event/EventApi.php
+++ b/app/src/Event/EventApi.php
@@ -236,23 +236,11 @@ class EventApi extends BaseApi
             $collectionData['events'][] = $thisEvent;
 
             // save the URL so we can look up by it
-            $this->saveEventUrl($thisEvent);
+            $this->eventDb->save($event);
         }
         $collectionData['pagination'] = $meta;
 
         return $collectionData;
-    }
-
-    /**
-     * Take an event and save the url_friendly_name and the API URL for that
-     *
-     * @param EventEntity $event The event to take details from
-     *
-     * @return void
-     */
-    private function saveEventUrl(EventEntity $event)
-    {
-        $this->eventDb->save($event);
     }
 
     /**

--- a/app/src/Event/EventApi.php
+++ b/app/src/Event/EventApi.php
@@ -54,18 +54,14 @@ class EventApi extends BaseApi
      */
     public function getByFriendlyUrl($friendlyUrl)
     {
-        $event = $this->eventDb->load('url_friendly_name', $friendlyUrl);
+        $item = $this->eventDb->load('url_friendly_name', $friendlyUrl);
 
-        if (!$event) {
+        if (!$item) {
             // don't throw an exception, Slim eats them
             return false;
         }
 
-        $event_list = json_decode($this->apiGet($event['verbose_uri']));
-        $event = new EventEntity($event_list->events[0]);
-
-        return $event;
-
+        return $this->getEvent($item['uri']);
     }
 
     /**
@@ -77,16 +73,13 @@ class EventApi extends BaseApi
      */
     public function getByStub($stub)
     {
-        $event = $this->eventDb->load('stub', $stub);
+        $item = $this->eventDb->load('stub', $stub);
 
-        if (!$event) {
+        if (!$item) {
             return false;
         }
 
-        $event_list = json_decode($this->apiGet($event['verbose_uri']));
-        $event = new EventEntity($event_list->events[0]);
-
-        return $event;
+        return $this->getEvent($item['uri']);
     }
 
     /**

--- a/app/src/Event/EventApi.php
+++ b/app/src/Event/EventApi.php
@@ -28,7 +28,7 @@ class EventApi extends BaseApi
      *
      * @return EventEntity model
      */
-    public function getFilteredCollection($limit = 10, $start = 1, $filter = null, $verbose = false, array $queryParams = [])
+    public function getEvents($limit = 10, $start = 1, $filter = null, $verbose = false, array $queryParams = [])
     {
         $url = $this->baseApiUrl . '/v2.1/events';
         $queryParams['resultsperpage'] = $limit;

--- a/app/src/Event/EventApi.php
+++ b/app/src/Event/EventApi.php
@@ -98,7 +98,9 @@ class EventApi extends BaseApi
 
         $talk_list = (array)json_decode($this->apiGet($event_uri, $params));
         if (isset($talk_list['events']) && isset($talk_list['events'][0])) {
-            return new EventEntity($talk_list['events'][0]);
+            $event = new EventEntity($talk_list['events'][0]);
+            $this->eventDb->save($event);
+            return $event;
         }
         
         return false;

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -164,8 +164,7 @@ class EventController extends BaseController
             $this->redirectToListPage();
         }
 
-        $keyPrefix = $this->cfg['redisKeyPrefix'];
-        $cache = new CacheService($keyPrefix);
+        $cache = $this->getCache();
         $talkDb = new TalkDb($cache);
         $talkApi = new TalkApi($this->cfg, $this->accessToken, $talkDb);
         $scheduler = new EventScheduler($talkApi);
@@ -319,8 +318,7 @@ class EventController extends BaseController
 
     protected function getEventApi()
     {
-        $keyPrefix = $this->cfg['redisKeyPrefix'];
-        $cache = new CacheService($keyPrefix);
+        $cache = $this->getCache();
         $eventDb = new EventDb($cache);
         $eventApi = new EventApi($this->cfg, $this->accessToken, $eventDb);
 
@@ -444,13 +442,19 @@ class EventController extends BaseController
     }
 
     /**
+     * @return CacheService
+     */
+    private function getCache()
+    {
+        $keyPrefix = $this->cfg['redisKeyPrefix'];
+        return new CacheService($keyPrefix);
+    }
+
+    /**
      * @return TalkDb
      */
     private function getTalkDb()
     {
-        $keyPrefix = $this->cfg['redisKeyPrefix'];
-        $cache = new CacheService($keyPrefix);
-
-        return new TalkDb($cache);
+        return new TalkDb($this->getCache());
     }
 }

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -43,7 +43,7 @@ class EventController extends BaseController
         $start = ($page -1) * $this->itemsPerPage;
 
         $eventApi = $this->getEventApi();
-        $events = $eventApi->getCollection(
+        $events = $eventApi->getFilteredCollection(
             $this->itemsPerPage,
             $start,
             'upcoming'
@@ -66,7 +66,7 @@ class EventController extends BaseController
         $start = ($page -1) * $this->itemsPerPage;
 
         $eventApi = $this->getEventApi();
-        $events = $eventApi->getCollection(
+        $events = $eventApi->getFilteredCollection(
             $this->itemsPerPage,
             $start,
             'cfp',

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -43,7 +43,7 @@ class EventController extends BaseController
         $start = ($page -1) * $this->itemsPerPage;
 
         $eventApi = $this->getEventApi();
-        $events = $eventApi->getFilteredCollection(
+        $events = $eventApi->getEvents(
             $this->itemsPerPage,
             $start,
             'upcoming'
@@ -66,7 +66,7 @@ class EventController extends BaseController
         $start = ($page -1) * $this->itemsPerPage;
 
         $eventApi = $this->getEventApi();
-        $events = $eventApi->getFilteredCollection(
+        $events = $eventApi->getEvents(
             $this->itemsPerPage,
             $start,
             'cfp',

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -165,8 +165,7 @@ class EventController extends BaseController
         }
 
         $cache = $this->getCache();
-        $talkDb = new TalkDb($cache);
-        $talkApi = new TalkApi($this->cfg, $this->accessToken, $talkDb);
+        $talkApi = $this->getTalkApi();
         $scheduler = new EventScheduler($talkApi);
 
         $schedule = $scheduler->getScheduleData($event);
@@ -422,8 +421,7 @@ class EventController extends BaseController
      */
     private function getTalkSlugsFromApi(EventEntity $event)
     {
-        $talkDb  = $this->getTalkDb();
-        $talkApi = new TalkApi($this->cfg, $this->accessToken, $talkDb);
+        $talkApi = $this->getTalkApi();
 
         // Fetch talks from the API
         $talks = $talkApi->getCollection(
@@ -433,7 +431,6 @@ class EventController extends BaseController
 
         /** @var \Talk\TalkEntity $talk */
         foreach ($talks['talks'] as $talk) {
-            $talkDb->save($talk); // Save to cache so we will get a hit next time
 
             $slugs[$talk->getApiUri()] = $talk->getUrlFriendlyTalkTitle();
         }
@@ -456,5 +453,13 @@ class EventController extends BaseController
     private function getTalkDb()
     {
         return new TalkDb($this->getCache());
+    }
+
+    /**
+     * @return TalkApi
+     */
+    private function getTalkApi()
+    {
+        return new TalkApi($this->cfg, $this->accessToken, $this->getTalkDb());
     }
 }

--- a/app/src/Search/SearchController.php
+++ b/app/src/Search/SearchController.php
@@ -86,7 +86,7 @@ class SearchController extends BaseController
             $start = ($page -1) * $this->itemsPerPage;
 
             $eventApi = $this->getEventApi();
-            $events = $eventApi->getCollection(
+            $events = $eventApi->getEvents(
                 $this->itemsPerPage,
                 $start,
                 null,

--- a/app/src/Talk/TalkApi.php
+++ b/app/src/Talk/TalkApi.php
@@ -59,7 +59,9 @@ class TalkApi extends BaseApi
 
         $collection = (array)json_decode($this->apiGet($talk_uri));
 
-        return new TalkEntity($collection['talks'][0]);
+        $talk = new TalkEntity($collection['talks'][0]);
+        $this->talkDb->save($talk);
+        return $talk;
     }
 
     /**

--- a/app/src/Talk/TalkApi.php
+++ b/app/src/Talk/TalkApi.php
@@ -35,10 +35,10 @@ class TalkApi extends BaseApi
         );
 
         $collectionData = array();
-        foreach ($talks['talks'] as $talk) {
-            $talkObject = new TalkEntity($talk);
-            $collectionData['talks'][] = $talkObject;
-            $this->talkDb->save($talkObject);
+        foreach ($talks['talks'] as $item) {
+            $talk = new TalkEntity($item);
+            $collectionData['talks'][] = $talk;
+            $this->talkDb->save($talk);
         }
 
         return $collectionData;
@@ -57,9 +57,9 @@ class TalkApi extends BaseApi
             $talk_uri = $talk_uri . '?verbose=yes';
         }
 
-        $talk = (array)json_decode($this->apiGet($talk_uri));
+        $collection = (array)json_decode($this->apiGet($talk_uri));
 
-        return new TalkEntity($talk['talks'][0]);
+        return new TalkEntity($collection['talks'][0]);
     }
 
     /**

--- a/app/src/Talk/TalkApi.php
+++ b/app/src/Talk/TalkApi.php
@@ -45,6 +45,23 @@ class TalkApi extends BaseApi
     }
 
     /**
+     * Gets a talk when we know the slug and event's uri.
+     *
+     * @param  string $talkSlug
+     * @param  string $eventUri
+     * @return TalkEntity
+     */
+    public function getTalkBySlug($talkSlug, $eventUri)
+    {
+        $talkUri = $this->talkDb->getUriFor($talkSlug, $eventUri);
+        if (!$talkUri) {
+            return false;
+        }
+
+        return $this->getTalk($talkUri, true);
+    }
+
+    /**
      * Gets talk data from api on single talk
      *
      * @param string $talk_uri  API talk uri

--- a/app/src/Talk/TalkController.php
+++ b/app/src/Talk/TalkController.php
@@ -28,17 +28,8 @@ class TalkController extends BaseController
             return Slim::getInstance()->notFound();
         }
 
-        $eventUri = $event->getUri();
-
-        $cache = $this->getCache();
-        $talkDb = new TalkDb($cache);
-        $talkUri = $talkDb->getUriFor($talkSlug, $eventUri);
-        if (!$talkUri) {
-            return Slim::getInstance()->notFound();
-        }
-
-        $talkApi = new TalkApi($this->cfg, $this->accessToken, $talkDb);
-        $talk = $talkApi->getTalk($talkUri, true);
+        $talkApi = $this->getTalkApi();
+        $talk = $talkApi->getTalkBySlug($talkSlug, $event->getUri());
         if (!$talk) {
             return Slim::getInstance()->notFound();
         }
@@ -91,14 +82,9 @@ class TalkController extends BaseController
 
         $eventApi = $this->getEventApi();
         $event = $eventApi->getByFriendlyUrl($eventSlug);
-        $eventUri = $event->getUri();
 
-        $cache = $this->getCache();
-        $talkDb = new TalkDb($cache);
-        $talkUri = $talkDb->getUriFor($talkSlug, $eventUri);
-
-        $talkApi = new TalkApi($this->cfg, $this->accessToken, $talkDb);
-        $talk = $talkApi->getTalk($talkUri, true);
+        $talkApi = $this->getTalkApi();
+        $talk = $talkApi->getTalkBySlug($talkSlug, $event->getUri());
         if ($talk) {
             try {
                 $talkApi->addComment($talk, $rating, $comment);
@@ -138,5 +124,14 @@ class TalkController extends BaseController
     {
         $eventDb = new EventDb($this->getCache());
         return new EventApi($this->cfg, $this->accessToken, $eventDb);
+    }
+
+    /**
+     * @return TalkApi
+     */
+    private function getTalkApi()
+    {
+        $talkDb = new TalkDb($this->getCache());
+        return new TalkApi($this->cfg, $this->accessToken, $talkDb);
     }
 }

--- a/app/src/Talk/TalkDb.php
+++ b/app/src/Talk/TalkDb.php
@@ -13,14 +13,22 @@ class TalkDb extends BaseDb
             'event_uri' => $eventUri,
             'slug' => $slug
         ));
-        return $data['uri'];
+
+        if ($data) {
+            return $data['uri'];
+        }
+
+        return null;
     }
 
     public function getSlugFor($talkUri)
     {
         $talk = $this->load('uri', $talkUri);
+        if ($talk) {
+            return $talk['slug'];
+        }
 
-        return $talk['slug'];
+        return null;
     }
 
     public function save(TalkEntity $talk)

--- a/app/src/User/UserApi.php
+++ b/app/src/User/UserApi.php
@@ -28,6 +28,8 @@ class UserApi extends BaseApi
                 if (isset($data->users) && isset($data->users[0])) {
                     $user = new UserEntity($data->users[0]);
 
+                    $this->userDb->save($user);
+
                     return $user;
                 }
 
@@ -136,6 +138,7 @@ class UserApi extends BaseApi
                     foreach ($data->users as $userData) {
                         if (strtolower($userData->username) == strtolower($username)) {
                             $user = new UserEntity($userData);
+                            $this->userDb->save($user);
                             return $user;
                         }
                     }

--- a/app/src/User/UserApi.php
+++ b/app/src/User/UserApi.php
@@ -129,9 +129,9 @@ class UserApi extends BaseApi
     public function getUserByUsername($username)
     {
         // do we already know this username's API URL?
-        $userUri = $this->userDb->load('username', $username);
-        if ($userUri) {
-            return $this->getUser($userUri['uri']);
+        $userInfo = $this->userDb->load('username', $username);
+        if ($userInfo) {
+            return $this->getUser($userInfo['uri']);
         }
 
         // fetch via filtering the users collection

--- a/app/src/User/UserApi.php
+++ b/app/src/User/UserApi.php
@@ -128,6 +128,13 @@ class UserApi extends BaseApi
      */
     public function getUserByUsername($username)
     {
+        // do we already know this username's API URL?
+        $userUri = $this->userDb->load('username', $username);
+        if ($userUri) {
+            return $this->getUser($userUri['uri']);
+        }
+
+        // fetch via filtering the users collection
         $url = $this->baseApiUrl . '/v2.1/users';
         $result = $this->apiGet($url, ['username' => $username, 'verbose'=>'yes']);
 

--- a/app/src/User/UserController.php
+++ b/app/src/User/UserController.php
@@ -241,8 +241,7 @@ class UserController extends BaseController
         }
 
         $cache = $this->getCache();
-        $talkDb = new TalkDb($cache);
-        $talkApi = new TalkApi($this->cfg, $this->accessToken, $talkDb);
+        $talkApi = $this->getTalkApi();
         $eventApi = $this->getEventApi();
 
         $eventInfo = array(); // look up an event's name and url_friendly_name from its uri
@@ -284,7 +283,6 @@ class UserController extends BaseController
             $talk = $talkApi->getTalk($comment->getTalkUri());
             if ($talk) {
                 $talkInfo[$comment->getTalkUri()]['url_friendly_talk_title'] = $talk->getUrlFriendlyTalkTitle();
-                $talkDb->save($talk, $talk->getEventUri());
 
                 // look up event's name & url_friendly_name from the API
                 if (!isset($eventInfo[$talk->getEventUri()])) {
@@ -327,6 +325,15 @@ class UserController extends BaseController
     {
         $cache = $this->getCache();
         return new UserApi($this->cfg, $this->accessToken, new UserDb($cache));
+    }
+
+    /**
+     * @return TalkApi
+     */
+    private function getTalkApi()
+    {
+        $talkDb = new TalkDb($this->getCache());
+        return new TalkApi($this->cfg, $this->accessToken, $talkDb);
     }
 
     /**

--- a/app/src/User/UserController.php
+++ b/app/src/User/UserController.php
@@ -266,13 +266,13 @@ class UserController extends BaseController
             }
         }
 
-        $eventsCollection = $eventApi->queryEvents($user->getAttendedEventsUri() . '?verbose=yes&resultsperpage=5');
+        $eventsCollection = $eventApi->getCollection($user->getAttendedEventsUri() . '?verbose=yes&resultsperpage=5');
         $events = false;
         if (isset($eventsCollection['events'])) {
             $events = $eventsCollection['events'];
         }
 
-        $hostedEventsCollection = $eventApi->queryEvents($user->getHostedEventsUri() . '?verbose=yes&resultsperpage=5');
+        $hostedEventsCollection = $eventApi->getCollection($user->getHostedEventsUri() . '?verbose=yes&resultsperpage=5');
         $hostedEvents = false;
         if (isset($hostedEventsCollection['events'])) {
             $hostedEvents = $hostedEventsCollection['events'];

--- a/app/src/User/UserController.php
+++ b/app/src/User/UserController.php
@@ -235,17 +235,9 @@ class UserController extends BaseController
     public function profile($username)
     {
         $userApi = $this->getUserApi();
-        $userDb = new UserDb($this->getCache());
-
-        $userInfo = $userDb->load('username', $username);
-        if ($userInfo) {
-            $user = $userApi->getUser($userInfo['uri']);
-        } else {
-            $user = $userApi->getUserByUsername($username);
-            if (!$user) {
-                Slim::getInstance()->notFound();
-            }
-            $userDb->save($user);
+        $user = $userApi->getUserByUsername($username);
+        if (!$user) {
+            Slim::getInstance()->notFound();
         }
 
         $cache = $this->getCache();

--- a/app/src/User/UserController.php
+++ b/app/src/User/UserController.php
@@ -243,8 +243,7 @@ class UserController extends BaseController
         $cache = $this->getCache();
         $talkDb = new TalkDb($cache);
         $talkApi = new TalkApi($this->cfg, $this->accessToken, $talkDb);
-        $eventDb = new EventDb($cache);
-        $eventApi = new EventApi($this->cfg, $this->accessToken, $eventDb);
+        $eventApi = $this->getEventApi();
 
         $eventInfo = array(); // look up an event's name and url_friendly_name from its uri
         $talkInfo = array(); // look up a talk's url_friendly_talk_title from its uri
@@ -258,7 +257,6 @@ class UserController extends BaseController
                 if (!isset($eventInfo[$talk->getEventUri()])) {
                     $event = $eventApi->getEvent($talk->getEventUri());
                     if ($event) {
-                        $eventDb->save($event);
                         $eventInfo[$talk->getApiUri()]['url_friendly_name'] = $event->getUrlFriendlyName();
                         $eventInfo[$talk->getApiUri()]['name'] = $event->getName();
                     }
@@ -292,7 +290,6 @@ class UserController extends BaseController
                 if (!isset($eventInfo[$talk->getEventUri()])) {
                     $event = $eventApi->getEvent($talk->getEventUri());
                     if ($event) {
-                        $eventDb->save($event);
                         $eventInfo[$talk->getApiUri()]['url_friendly_name'] = $event->getUrlFriendlyName();
                         $eventInfo[$talk->getApiUri()]['name'] = $event->getName();
                     }
@@ -330,5 +327,14 @@ class UserController extends BaseController
     {
         $cache = $this->getCache();
         return new UserApi($this->cfg, $this->accessToken, new UserDb($cache));
+    }
+
+    /**
+     * @return EventApi
+     */
+    private function getEventApi()
+    {
+        $eventDb = new EventDb($this->getCache());
+        return new EventApi($this->cfg, $this->accessToken, $eventDb);
     }
 }

--- a/app/src/User/UserDb.php
+++ b/app/src/User/UserDb.php
@@ -7,7 +7,7 @@ class UserDb extends BaseDb
 {
     protected $keyName = 'users';
 
-    public function save($user)
+    public function save(UserEntity $user)
     {
         $data = array(
             'uri'  => $user->getUri(),

--- a/tests/Event/EventApiTest.php
+++ b/tests/Event/EventApiTest.php
@@ -22,7 +22,7 @@ class EventApiTest extends \PHPUnit_Framework_TestCase
 
     }
 
-    public function testDefaultGetCollectionParametersAreSet()
+    public function testDefaultgetEventsParametersAreSet()
     {
         $mockEvent = $this->getMock(
             'Event\EventApi',
@@ -36,10 +36,10 @@ class EventApiTest extends \PHPUnit_Framework_TestCase
             ->with('http://example.com/v2.1/events', $expectedParams)
             ->will($this->returnValue(json_encode(array('events' => array(), 'meta' => array()))));
 
-        $mockEvent->getCollection();
+        $mockEvent->getEvents();
     }
 
-    public function testGetCollectionWithLimitSetsParamsCorrectly()
+    public function testgetEventsWithLimitSetsParamsCorrectly()
     {
         $mockEvent = $this->getMock(
             'Event\EventApi',
@@ -53,10 +53,10 @@ class EventApiTest extends \PHPUnit_Framework_TestCase
             ->with('http://example.com/v2.1/events', $expectedParams)
             ->will($this->returnValue(json_encode(array('events' => array(), 'meta' => array()))));
 
-        $mockEvent->getCollection(75);
+        $mockEvent->getEvents(75);
     }
 
-    public function testGetCollectionWithPageValueSetsParamsCorrectly()
+    public function testgetEventsWithPageValueSetsParamsCorrectly()
     {
         $mockEvent = $this->getMock(
             'Event\EventApi',
@@ -70,10 +70,10 @@ class EventApiTest extends \PHPUnit_Framework_TestCase
             ->with('http://example.com/v2.1/events', $expectedParams)
             ->will($this->returnValue(json_encode(array('events' => array(), 'meta' => array()))));
 
-        $mockEvent->getCollection(32, 6);
+        $mockEvent->getEvents(32, 6);
     }
 
-    public function testGetCollectionWithFilterSetsAllParamsCorrectly()
+    public function testgetEventsWithFilterSetsAllParamsCorrectly()
     {
         $mockEvent = $this->getMock(
             'Event\EventApi',
@@ -87,10 +87,10 @@ class EventApiTest extends \PHPUnit_Framework_TestCase
             ->with('http://example.com/v2.1/events', $expectedParams)
             ->will($this->returnValue(json_encode(array('events' => array(), 'meta' => array()))));
 
-        $mockEvent->getCollection(16, 3, 'samoflange');
+        $mockEvent->getEvents(16, 3, 'samoflange');
     }
 
-    public function testGetCollectionWithVerboseSetsAllParamsCorrectly()
+    public function testgetEventsWithVerboseSetsAllParamsCorrectly()
     {
         $mockEvent = $this->getMock(
             'Event\EventApi',
@@ -104,10 +104,10 @@ class EventApiTest extends \PHPUnit_Framework_TestCase
             ->with('http://example.com/v2.1/events', $expectedParams)
             ->will($this->returnValue(json_encode(array('events' => array(), 'meta' => array()))));
 
-        $mockEvent->getCollection(16, 3, null, true);
+        $mockEvent->getEvents(16, 3, null, true);
     }
 
-    public function testGetCollectionWithQueryParamsPassesThemThroughCorrectly()
+    public function testgetEventsWithQueryParamsPassesThemThroughCorrectly()
     {
         $mockEvent = $this->getMock(
             'Event\EventApi',
@@ -121,7 +121,7 @@ class EventApiTest extends \PHPUnit_Framework_TestCase
             ->with('http://example.com/v2.1/events', $expectedParams)
             ->will($this->returnValue(json_encode(array('events' => array(), 'meta' => array()))));
 
-        $mockEvent->getCollection(16, 3, null, false, array('title' => 'test', 'tags' => 'php'));
+        $mockEvent->getEvents(16, 3, null, false, array('title' => 'test', 'tags' => 'php'));
     }
 
     /**


### PR DESCRIPTION
Main things:

* Renamed EventApi's getCollection to getEvents and queryEvents to getCollection to be consistent with TalkApi
* In all controllers we now have a set of get methods which handle creation of CacheService, Db and Api objects as required. This ensures that we don't accidentally create two CacheService instances by accident and makes it clearer what's going on in the controller methods as there's a little less boilerplate.
* EventApi's getByFriendlyUrl and getByStub now use getEvent so that they also save to eventDb on successful retrieve.
* Tidied variable names so that a $talk or $event is always an Entity.
* Fixed trying to access an array element that may not exist in TalkDb.
* Ensure that we save the meta data to the db object consistently in the Api classes whenever we retrieve data from the API, so that the controller doesn't have to remember to do this.