### PR TITLE
Event ratings

### DIFF
--- a/app/src/Event/EventApi.php
+++ b/app/src/Event/EventApi.php
@@ -142,11 +142,12 @@ class EventApi extends BaseApi
         return $commentData;
     }
 
-    public function addComment($event, $comment)
+    public function addComment($event, $comment, $rating = 0)
     {
         $uri = $event->getCommentsUri();
         $params = array(
             'comment' => $comment,
+            'rating' => $rating,
         );
         list ($status, $result) = $this->apiPost($uri, $params);
 

--- a/app/src/Event/EventCommentEntity.php
+++ b/app/src/Event/EventCommentEntity.php
@@ -69,4 +69,13 @@ class EventCommentEntity
         $hash = md5($this->data->comment_uri);
         return (substr($hash, 0, 6));
     }
+
+    public function getRating()
+    {
+        if (!isset($this->data->rating)) {
+            return null;
+        }
+
+        return $this->data->rating;
+    }
 }

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -196,6 +196,7 @@ class EventController extends BaseController
     {
         $request = $this->application->request();
         $comment = $request->post('comment');
+        $rating = (int) $request->post('rating');
         $url = $this->application->urlFor("event-detail", array('friendly_name' => $friendly_name));
         $url .= '#add-comment';
 
@@ -203,7 +204,7 @@ class EventController extends BaseController
         $event = $eventApi->getByFriendlyUrl($friendly_name);
         if ($event) {
             try {
-                $eventApi->addComment($event, $comment);
+                $eventApi->addComment($event, $comment, $rating);
             } catch (Exception $e) {
                 if (stripos($e->getMessage(), 'duplicate comment') !== false) {
                     // duplicate comment

--- a/app/src/Event/EventEntity.php
+++ b/app/src/Event/EventEntity.php
@@ -478,4 +478,9 @@ class EventEntity
 
         return $this->data->hosts;
     }
+
+    public function getAverageRating()
+    {
+        return $this->data->event_average_rating;
+    }
 }

--- a/app/templates/Event/details.html.twig
+++ b/app/templates/Event/details.html.twig
@@ -102,6 +102,13 @@
         </section>
     {% endif %}
 
+    {% if event.getAverageRating %}
+    <section>
+        {% include '_common/rating.html.twig' with {'rating': event.averageRating, 'style': 'vertical'} %}
+    </section>
+    {% endif %}
+
+
 {% endblock %}
 
 {% block extra_meta %}

--- a/app/templates/Event/details.html.twig
+++ b/app/templates/Event/details.html.twig
@@ -20,9 +20,31 @@
                                     <div class="alert alert-danger">{{flash.getMessages.error}}</div>
                                 {% endif %}
                                 <form id="add-comment" role="form" method="POST" action="{{ urlFor('event-add-comment', {'friendly_name': event.getUrlFriendlyName}) }}">
-                                    <div class="form-group">
-                                        <label for="comment">Your comment:</label>
-                                        <textarea id="comment" class="form-control" name="comment"></textarea>
+                                    <div class="row">
+                                        <div class="col-sm-9">
+                                            <div class="form-group">
+                                                <label for="comment">Your comment:</label>
+                                                <textarea id="comment" class="form-control" name="comment"></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="col-sm-3 text-right">
+                                            <div class="rating-vote-container">
+                                                <div id="rating_container" class="form-group">
+                                                    <label for="rating">Rate the event:</label>
+                                                    <select id="rating" name="rating">
+                                                        <option value="0"></option>
+                                                        <option value="1">Needed better organization</option>
+                                                        <option value="2">Had potential</option>
+                                                        <option value="3">Worth attending</option>
+                                                        <option value="4">Great event</option>
+                                                        <option value="5">Brilliant event!</option>
+                                                    </select>
+                                                    <br>
+                                                    <div class="rateit" id="rating_widget" data-rateit-backingfld="#rating" data-rateit-starwidth="23" data-rateit-starheight="21" data-rateit-resetable="false"></div>
+                                                    <div id="rating_value"></div>
+                                                </div>
+                                            </div>
+                                        </div>
                                     </div>
                                     <div class="form-group">
                                         <button type="submit" class="btn btn-primary">Submit comment</button>
@@ -86,4 +108,17 @@
     {{ parent() }}
     <link rel="canonical" href="{{ urlFor('event-detail', {"friendly_name": event.getUrlFriendlyName}) }}" />
     {% if event.getStub %}<link rel="shortlink" href="{{ shortUrlForEvent(event.getStub) }}" />{% endif %}
+{% endblock %}
+
+{% block extra_javascript %}
+    <script type="text/javascript">
+        $('#rating_widget').bind('over', function (event, value) {
+            if (value) {
+                $("#rating_value").html($("#rating option[value='"+value+"']").text());
+            } else {
+                $("#rating_value").html($("#rating option:selected").text())
+            }
+        });
+        $('#rating_widget').bind('rated', function (event, value) { $("#rating_value").html($("#rating option[value='"+value+"']").text()) });
+    </script>
 {% endblock %}

--- a/tests/Event/EventApiTest.php
+++ b/tests/Event/EventApiTest.php
@@ -170,13 +170,16 @@ class EventApiTest extends \PHPUnit_Framework_TestCase
             ->method('apiPost')
             ->with(
                 'http://example.com/comments/123',
-                array('comment'=>'comment')
+                array(
+                    'comment' => 'comment',
+                    'rating' => 3,
+                )
             )
             ->will($this->returnValue(array('201', 'result')));
 
         // The test
         $this->assertTrue(
-            $mockEventApi->addComment($mockEventObj, 'comment')
+            $mockEventApi->addComment($mockEventObj, 'comment', 3)
         );
     }
 
@@ -213,7 +216,10 @@ class EventApiTest extends \PHPUnit_Framework_TestCase
             ->method('apiPost')
             ->with(
                 'http://example.com/comments/123',
-                array('comment'=>'comment')
+                array(
+                    'comment' => 'comment',
+                    'rating' => 0,
+                )
             )
             ->will($this->returnValue(array('500', 'no result')));
 


### PR DESCRIPTION
Allow a user to optionally rate an event when commenting. 
Display the average rating for an event if it's not zero.

This should be merged after API PRS: [171](https://github.com/joindin/joindin-api/pull/171) & [172](https://github.com/joindin/joindin-api/pull/172)

JOINDIN-544 #close Fixed.