### PR TITLE
Only show map if co-ordinates exist and are not 0

### DIFF
--- a/app/templates/Event/details.html.twig
+++ b/app/templates/Event/details.html.twig
@@ -48,7 +48,11 @@
 
     <p>{{ event.getDescription|nl2br }}</p>
 
-    <div id="streetmap" style="border: 1px solid black; height: 300px;"></div>
+
+    {% if event.getLatitude != '0' and event.getLongitude != '0' %}
+        <div id="streetmap" style="border: 1px solid black; height: 300px;"></div>
+    {% endif %}
+
 {% endblock %}
 
 {% block extraAside %}


### PR DESCRIPTION
Ensures that map will only display if co-ordinates have been set and are not 0

Fixes #JOINDIN-560