### PR TITLE
Sign in with twitter

### DIFF
--- a/app/src/User/AuthApi.php
+++ b/app/src/User/AuthApi.php
@@ -36,4 +36,56 @@ class AuthApi extends BaseApi
         }
         return false;
     }
+
+    /**
+     * Get a request token from the API from Twitter
+     *
+     * @param  string $clientId OAuth client ID
+     * @param  string $clientSecret OAuth client secret
+     * @return string The token
+     */
+    public function getTwitterRequestToken($clientId, $clientSecret) {
+        $url = $this->baseApiUrl . '/v2.1/twitter/request_token';
+        $params = array(
+            'client_id'     => $clientId,
+            'client_secret' => $clientSecret,
+        );
+
+        list ($status, $result, $headers) = $this->apiPost($url, $params);
+        if ($status == 201) {
+            // we got one, data is actually in the body
+            $data = json_decode($result, true);
+            if ($data) {
+                return $data['token'];
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Send Twitter verification token to the API to log us in
+     *
+     * @param  string $clientId OAuth client ID
+     * @param  string $clientSecret OAuth client secret
+     */
+    public function verifyTwitter($clientId, $clientSecret, $token, $verifier) {
+        $url = $this->baseApiUrl . '/v2.1/twitter/token';
+        $params = array(
+            'client_id'     => $clientId,
+            'client_secret' => $clientSecret,
+            'token'         => $token,
+            'verifier'      => $verifier,
+        );
+
+        list ($status, $result, $headers) = $this->apiPost($url, $params);
+        if ($result) {
+            $data = json_decode($result);
+            if ($data) {
+                if (isset($data->access_token)) {
+                    return $data;
+                }
+            }
+        }
+        return false;
+    }
 }

--- a/app/src/User/AuthApi.php
+++ b/app/src/User/AuthApi.php
@@ -54,9 +54,10 @@ class AuthApi extends BaseApi
         list ($status, $result, $headers) = $this->apiPost($url, $params);
         if ($status == 201) {
             // we got one, data is actually in the body
-            $data = json_decode($result, true);
+            $data = json_decode($result);
             if ($data) {
-                return $data['token'];
+                $token = $data->twitter_request_tokens[0];
+                return $token->token;
             }
         }
         return false;

--- a/app/src/User/AuthApi.php
+++ b/app/src/User/AuthApi.php
@@ -44,7 +44,8 @@ class AuthApi extends BaseApi
      * @param  string $clientSecret OAuth client secret
      * @return string The token
      */
-    public function getTwitterRequestToken($clientId, $clientSecret) {
+    public function getTwitterRequestToken($clientId, $clientSecret)
+    {
         $url = $this->baseApiUrl . '/v2.1/twitter/request_token';
         $params = array(
             'client_id'     => $clientId,
@@ -69,7 +70,8 @@ class AuthApi extends BaseApi
      * @param  string $clientId OAuth client ID
      * @param  string $clientSecret OAuth client secret
      */
-    public function verifyTwitter($clientId, $clientSecret, $token, $verifier) {
+    public function verifyTwitter($clientId, $clientSecret, $token, $verifier)
+    {
         $url = $this->baseApiUrl . '/v2.1/twitter/token';
         $params = array(
             'client_id'     => $clientId,

--- a/app/src/User/UserController.php
+++ b/app/src/User/UserController.php
@@ -33,6 +33,8 @@ class UserController extends BaseController
             ->via('GET', 'POST')->name('user-password-reset');
         $app->map('/user/new-password', array($this, 'newPassword'))
             ->via('GET', 'POST')->name('user-new-password');
+        $app->get('/user/twitter-login', array($this, 'loginWithTwitter'))->name('twitter-login');
+        $app->get('/user/twitter-access', array($this, 'accessTokenTwitter'))->name('twitter-callback');
         $app->get('/user/:username', array($this, 'profile'))->name('user-profile');
         $app->get('/user/:username/talks', array($this, 'profileTalks'))->name('user-profile-talks');
         $app->get('/user/:username/events', array($this, 'profileEvents'))->name('user-profile-events');
@@ -64,31 +66,7 @@ class UserController extends BaseController
             $authApi = new AuthApi($this->cfg, $this->accessToken);
             $result = $authApi->login($username, $password, $clientId, $clientSecret);
 
-            if (false === $result) {
-                $this->application->flash('error', "Failed to log in");
-                if (empty($redirect)) {
-                    $redirect = '/user/login';
-                }
-                $this->application->redirect($redirect);
-            } else {
-                session_regenerate_id(true);
-                $_SESSION['access_token'] = $result->access_token;
-                $this->accessToken = $_SESSION['access_token'];
-
-                // now get users details
-                $userApi = $this->getUserApi();
-                $user = $userApi->getUser($result->user_uri);
-                if ($user) {
-                    $_SESSION['user'] = $user;
-                    if (empty($redirect) || strpos($redirect, '/user/login') === 0) {
-                        $this->application->redirect('/');
-                    } else {
-                        $this->application->redirect($redirect);
-                    }
-                } else {
-                    unset($_SESSION['access_token']);
-                }
-            }
+            $this->handleLogin($result, $redirect);
         }
 
         $this->render('User/login.html.twig');
@@ -794,5 +772,80 @@ class UserController extends BaseController
                 'form' => $form->createView(),
             )
         );
+    }
+
+    /**
+     * This gets a request token via the API, and forwards the user
+     * to twitter to log in and grant us access
+     */
+    public function loginWithTwitter() {
+        // ask the API for a request token
+        $config = $this->application->config('oauth');
+        $clientId = $config['client_id'];
+        $clientSecret = $config['client_secret'];
+
+        $authApi = new AuthApi($this->cfg, $this->accessToken);
+        $request_token = $authApi->getTwitterRequestToken($clientId, $clientSecret);
+
+        if($request_token) {
+            // forward the user
+            header("Location: https://api.twitter.com/oauth/authenticate?oauth_token=" . $request_token);
+            exit;
+        }
+
+        $this->application->flash(
+            'error',
+            'We could not log you in with twitter'
+        );
+        $this->application->redirect('/user/login');
+    }
+
+    /**
+     * The callback URL should point to here
+     */
+    public function accessTokenTwitter() {
+        $config = $this->application->config('oauth');
+        $request = $this->application->request();
+
+        // pass verification to the API so we can log in
+        $clientId = $config['client_id'];
+        $clientSecret = $config['client_secret'];
+
+        // handle incoming vars
+        $token = $request->get('oauth_token');
+        $verifier = $request->get('oauth_verifier');
+
+        $authApi = new AuthApi($this->cfg, $this->accessToken);
+        $result = $authApi->verifyTwitter($clientId, $clientSecret, $token, $verifier);
+
+        $this->handleLogin($result);
+    }
+
+    protected function handleLogin($result, $redirect = false) {
+        if (false === $result) {
+            $this->application->flash('error', "Failed to log in");
+            if (empty($redirect)) {
+                $redirect = '/user/login';
+            }
+            $this->application->redirect($redirect);
+        } else {
+            session_regenerate_id(true);
+            $_SESSION['access_token'] = $result->access_token;
+            $this->accessToken = $_SESSION['access_token'];
+
+            // now get users details
+            $userApi = $this->getUserApi();
+            $user = $userApi->getUser($result->user_uri);
+            if ($user) {
+                $_SESSION['user'] = $user;
+                if (empty($redirect) || strpos($redirect, '/user/login') === 0) {
+                    $this->application->redirect('/');
+                } else {
+                    $this->application->redirect($redirect);
+                }
+            } else {
+                unset($_SESSION['access_token']);
+            }
+        }
     }
 }

--- a/app/src/User/UserController.php
+++ b/app/src/User/UserController.php
@@ -778,7 +778,8 @@ class UserController extends BaseController
      * This gets a request token via the API, and forwards the user
      * to twitter to log in and grant us access
      */
-    public function loginWithTwitter() {
+    public function loginWithTwitter()
+    {
         // ask the API for a request token
         $config = $this->application->config('oauth');
         $clientId = $config['client_id'];
@@ -787,7 +788,7 @@ class UserController extends BaseController
         $authApi = new AuthApi($this->cfg, $this->accessToken);
         $request_token = $authApi->getTwitterRequestToken($clientId, $clientSecret);
 
-        if($request_token) {
+        if ($request_token) {
             // forward the user
             header("Location: https://api.twitter.com/oauth/authenticate?oauth_token=" . $request_token);
             exit;
@@ -803,7 +804,8 @@ class UserController extends BaseController
     /**
      * The callback URL should point to here
      */
-    public function accessTokenTwitter() {
+    public function accessTokenTwitter()
+    {
         $config = $this->application->config('oauth');
         $request = $this->application->request();
 
@@ -821,7 +823,8 @@ class UserController extends BaseController
         $this->handleLogin($result);
     }
 
-    protected function handleLogin($result, $redirect = false) {
+    protected function handleLogin($result, $redirect = false)
+    {
         if (false === $result) {
             $this->application->flash('error', "Failed to log in");
             if (empty($redirect)) {

--- a/app/templates/_common/login.html.twig
+++ b/app/templates/_common/login.html.twig
@@ -16,6 +16,7 @@
     <div class="form-group">
         <input type="submit" class="btn btn-primary" value="Log in">
         <a class="btn btn-link" href="{{ urlFor('user-register') }}">or register now</a>
+        <a class="btn btn-link" href="{{ urlFor('twitter-login') }}">Log in with twitter</a>
     </div>
     <div>
         Problems logging in? <a class="btn btn-link" href="{{ urlFor('user-resend-verification') }}">Resend welcome email</a>


### PR DESCRIPTION
This relies on the related API pull request: https://github.com/joindin/joindin-api/pull/190 and will also fix #463

Adds a "log in with twitter" link to the login page which should prompt you to grant access for joind.in to read only on your twitter account (prompting you to log in with twitter as appropriate).  If the twitter nick you sign in as is listed on a joind.in account, we'll sign you in as that account.

Does not cover:
 - registration
 - the fact that twitter accounts aren't unique