### PR TITLE
Retrieve host username in event collection

### DIFF
--- a/app/src/Event/EventApi.php
+++ b/app/src/Event/EventApi.php
@@ -277,6 +277,13 @@ class EventApi extends BaseApi
         $collectionData = array();
         foreach ($events['events'] as $item) {
             $event = new EventEntity($item);
+
+            foreach ($event->getHosts() as $hostsInfo) {
+                if (isset($hostsInfo->host_uri)) {
+                    $hostsInfo->username = $this->userApi->getUsername($hostsInfo->host_uri);
+                }
+            }
+            
             $collectionData['events'][] = $event;
 
             // save the URL so we can look up by it


### PR DESCRIPTION
After creating the event entity object for each event in the collection we need to find the username of each host so that we can link to them.

This is currently used in the pending events list page, but due to the caching in redis, is not an especially expensive operation to do anyway.

To test this, look at the Pending events list page and note that before this patch, the host's name is unlinked, and then when applied, the name is linked to their profile.