### PR TITLE
Enables automatic textarea expansion on comment fields

### DIFF
--- a/app/templates/Event/comments.html.twig
+++ b/app/templates/Event/comments.html.twig
@@ -89,5 +89,10 @@
             }
         });
         $('#rating_widget').bind('rated', function (event, value) { $("#rating_value").html($("#rating option[value='"+value+"']").text()) });
+        $("#comment").keyup(function(e) {
+            while($(this).outerHeight() < this.scrollHeight + parseFloat($(this).css("borderTopWidth")) + parseFloat($(this).css("borderBottomWidth"))) {
+                $(this).height($(this).height()+1);
+            };
+        });
     </script>
 {% endblock %}

--- a/app/templates/Talk/index.html.twig
+++ b/app/templates/Talk/index.html.twig
@@ -12,6 +12,11 @@
             }
         });
         $('#rating_widget').bind('rated', function (event, value) { $("#rating_value").html($("#rating option[value='"+value+"']").text()) });
+        $("#comment").keyup(function(e) {
+            while($(this).outerHeight() < this.scrollHeight + parseFloat($(this).css("borderTopWidth")) + parseFloat($(this).css("borderBottomWidth"))) {
+                $(this).height($(this).height()+1);
+            };
+        });
     </script>
 {% endblock %}
 


### PR DESCRIPTION
As a visitor enters a comment, once the comment exceeds default of 7
lines it will start to expand the textarea vertically.

Closes #JOINDIN-589