### PR TITLE
Config to make all API calls go through a proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,14 @@ Octocat gives [a good starting point](https://gist.github.com/octocat/9257657) f
     nbproject/private/
 
 For more info on ignoring files, [github has an excellent help page](https://help.github.com/articles/ignoring-files/).
+
+## Using A Proxy
+
+Since web2 then calls the API, it can be tricky to see what is going on.  You can use a proxy tool such as Charles Proxy or mitmproxy to observe the requests that are being made by enabling the `proxy` setting in the config with a line that looks something like this:
+
+    'proxy' => 'tcp://10.0.2.2:8888',
+
+If the proxy tool is running on your host machine, you'll need to understand what IP address the guest thinks your host has, the easiest way to do that is to `vagrant ssh` into the VM and then type `last` to see where it thinks you logged in from.
+
+Alternatively, try [Lorna's blog post about Wiresharking a VM](http://www.lornajane.net/posts/2014/wireshark-capture-on-remote-server).
+     

--- a/app/src/Application/BaseApi.php
+++ b/app/src/Application/BaseApi.php
@@ -42,6 +42,7 @@ class BaseApi
 
         if ($this->proxy) {
             $contextOpts['http']['proxy'] = $this->proxy;
+            $contextOpts['http']['request_fulluri'] = true;
         }
 
         $streamContext = stream_context_create($contextOpts);
@@ -77,6 +78,7 @@ class BaseApi
 
         if ($this->proxy) {
             $contextOpts['http']['proxy'] = $this->proxy;
+            $contextOpts['http']['request_fulluri'] = true;
         }
 
         $streamContext = stream_context_create($contextOpts);
@@ -119,6 +121,7 @@ class BaseApi
         
         if ($this->proxy) {
             $contextOpts['http']['proxy'] = $this->proxy;
+            $contextOpts['http']['request_fulluri'] = true;
         }
 
         $streamContext = stream_context_create($contextOpts);
@@ -160,6 +163,7 @@ class BaseApi
 
         if ($this->proxy) {
             $contextOpts['http']['proxy'] = $this->proxy;
+            $contextOpts['http']['request_fulluri'] = true;
         }
 
         $streamContext = stream_context_create($contextOpts);

--- a/app/src/Application/BaseApi.php
+++ b/app/src/Application/BaseApi.php
@@ -5,11 +5,16 @@ class BaseApi
 {
     protected $baseApiUrl;
     protected $accessToken;
+    protected $proxy;
 
     public function __construct($config, $accessToken)
     {
         if (isset($config['apiUrl'])) {
             $this->baseApiUrl = $config['apiUrl'];
+        }
+
+        if (isset($config['proxy']) && $config['proxy']) {
+            $this->proxy = $config['proxy'];
         }
 
         $this->accessToken = $accessToken;
@@ -33,6 +38,10 @@ class BaseApi
 
         if ($this->accessToken) {
             $contextOpts['http']['header'] .= "\r\nAuthorization: OAuth {$this->accessToken}";
+        }
+
+        if ($this->proxy) {
+            $contextOpts['http']['proxy'] = $this->proxy;
         }
 
         $streamContext = stream_context_create($contextOpts);
@@ -64,6 +73,10 @@ class BaseApi
 
         if ($this->accessToken) {
             $contextOpts['http']['header'] .= "\r\nAuthorization: OAuth {$this->accessToken}";
+        }
+
+        if ($this->proxy) {
+            $contextOpts['http']['proxy'] = $this->proxy;
         }
 
         $streamContext = stream_context_create($contextOpts);
@@ -104,6 +117,10 @@ class BaseApi
             $contextOpts['http']['header'] .= "\r\nAuthorization: OAuth {$this->accessToken}";
         }
         
+        if ($this->proxy) {
+            $contextOpts['http']['proxy'] = $this->proxy;
+        }
+
         $streamContext = stream_context_create($contextOpts);
         $result = file_get_contents($url, 0, $streamContext);
         if (false === $result) {
@@ -139,6 +156,10 @@ class BaseApi
 
         if ($this->accessToken) {
             $contextOpts['http']['header'] .= "\r\nAuthorization: OAuth {$this->accessToken}";
+        }
+
+        if ($this->proxy) {
+            $contextOpts['http']['proxy'] = $this->proxy;
         }
 
         $streamContext = stream_context_create($contextOpts);

--- a/config/config.php.dist
+++ b/config/config.php.dist
@@ -7,6 +7,7 @@ $config = array(
             'redisKeyPrefix' => 'dev-',
             'apiUrl' => 'https://api.joind.in',
             'googleAnalyticsId' => '',
+            'proxy' => '',
         ),
         'oauth' => array(
             'client_id' => 'web2',


### PR DESCRIPTION
When debugging, I find it helpful to push my API calls through a proxy such as Charles or mitmproxy, but it needs a minor modification to the code that makes the API calls to add the proxy setting to the stream context.  This patch makes this configurable and doesn't proxy if the setting is missing or empty.