### PR TITLE
Remove unused talk end time variable

### DIFF
--- a/app/src/Talk/TalkApi.php
+++ b/app/src/Talk/TalkApi.php
@@ -205,8 +205,7 @@ class TalkApi extends BaseApi
         foreach ($talks as $talk) {
             $date = $talk->getStartDateTime()->format("Y-m-d");
             $startTime = $talk->getStartDateTime()->format("H:i");
-            $endTime = $talk->getEndDateTime()->format("H:i");
-            $time = "$startTime";// - $endTime";
+            $time = "$startTime";
             $agenda[$date][$time][] = $talk;
         }
 


### PR DESCRIPTION
JOINDIN-605 #close Fixed.

TalkEntity::getEndDateTime() can return null when the duration is not
set. This means that format method of the date cannot be used. Since the
variable $endTime is not being used anyway, it should be removed.

Before merging this, we should consider whether
TalkEntity::getEndDateTime() is still needed? I've found no other uses
of this and am happy to amend this PR to include the removal of this 
method should that be preferable.