### PR TITLE
JOINDIN-614 - Fix link to event comments

### DIFF
--- a/app/templates/Event/_common/summary.html.twig
+++ b/app/templates/Event/_common/summary.html.twig
@@ -33,7 +33,7 @@ set eventUrl = urlFor(
 
                 |
 
-                <a href="{{ eventUrl }}#comments">
+                <a href="{{ eventUrl }}/comments">
                     {{ event.getCommentsCount}}
                     {% if event.getCommentsCount == 1 %}
                         comment

--- a/app/templates/Talk/_common/summary.html.twig
+++ b/app/templates/Talk/_common/summary.html.twig
@@ -26,7 +26,7 @@ set eventUrl = urlFor(
 
                 |
 
-                <a href="{{ talkUrl }}#comments" class="nowrap">
+                <a href="{{ talkUrl }}/comments" class="nowrap">
                     {{ talk.getCommentCount}}
                     {% if talk.getCommentCount == 1 %}
                         comment

--- a/app/templates/_common/eventtitle.html.twig
+++ b/app/templates/_common/eventtitle.html.twig
@@ -14,7 +14,7 @@
 
             |
 
-            <a href="{{ event.getUrl }}#comments">
+            <a href="{{ event.getUrl }}/comments">
                 {{ event.getCommentsCount}} comments</a> |
             {{ event.getAttendeeString|escape }}
             <!--| <a href="" class="button">I'm attending</a>-->


### PR DESCRIPTION
Link to comments has to be a slash instead of a hash.

Fixes: https://joindin.jira.com/browse/JOINDIN-614