### PR TITLE
Add starting span and class name

### DIFF
--- a/app/templates/Event/details.html.twig
+++ b/app/templates/Event/details.html.twig
@@ -1,7 +1,7 @@
 {% extends '/layout.html.twig' %}
 
 {% block title %}{{ event.getName }} - Joind.in{% endblock %}
-    
+
 {% block body %}
     {% include 'Event/_common/event_header.html.twig' %}
 
@@ -20,7 +20,7 @@
                     {% endif %}
 
                     {% if event.getAttendeeCount %}
-                        {{ event.getAttendeeCount|escape }}</span> people
+                        <span class="{{ event.getUrlFriendlyName|escape }}-attending-count">{{ event.getAttendeeCount|escape }}</span> people
                         {% if event.isPastEvent() %}attended{% else %}attending{% endif %}
                     {% endif %}
 


### PR DESCRIPTION
When clicking on "I went to this event" on event page update count on attendees
Example of bug was in:
{{Joind-in-environment}}/event/{{event-name}}