### PR TITLE
Joindin 532 apostrophe in event

### DIFF
--- a/app/src/Event/EventEntity.php
+++ b/app/src/Event/EventEntity.php
@@ -23,7 +23,7 @@ class EventEntity
             return null;
         }
 
-        return $this->data->name;
+        return htmlspecialchars_decode($this->data->name, ENT_QUOTES);
     }
 
     public function setName($name)
@@ -93,8 +93,7 @@ class EventEntity
         if (!isset($this->data->location)) {
             return null;
         }
-
-        return $this->data->location;
+        return htmlspecialchars_decode($this->data->location, ENT_QUOTES);
     }
 
     public function setLocation($location)
@@ -107,8 +106,7 @@ class EventEntity
         if (!isset($this->data->description)) {
             return null;
         }
-
-        return $this->data->description;
+        return htmlspecialchars_decode($this->data->description, ENT_QUOTES);
     }
 
     public function setDescription($description)

--- a/app/templates/Event/_common/summary.html.twig
+++ b/app/templates/Event/_common/summary.html.twig
@@ -13,7 +13,7 @@ set eventUrl = urlFor(
     <div class="title description">
         <section>
             <h3 class="header">
-                <a href="{{ eventUrl }}">{{ event.getName }}</a>
+                <a href="{{ eventUrl }}">{{ event.getName|e('html') }}</a>
             </h3>
 
             <p class="meta">
@@ -21,14 +21,14 @@ set eventUrl = urlFor(
             </p>
 
             <p class="wideOnly">
-                {{ event.getDescription | slice(0, 200)}}&hellip;
+                {{ event.getDescription | slice(0, 200) | e('html')}}&hellip;
             </p>
 
             <p class="meta">
                 {{ dateRange(event.getStartDate, event.getEndDate, 'j M Y') }}
 
                 {% if event.getLocation %}
-                    @ {{event.getLocation|escape}}
+                    @ {{event.getLocation|escape('html')}}
                 {% endif %}
 
                 |

--- a/app/templates/Event/details.html.twig
+++ b/app/templates/Event/details.html.twig
@@ -1,6 +1,6 @@
 {% extends '/layout.html.twig' %}
 
-{% block title %}{{ event.getName }} - Joind.in{% endblock %}
+{% block title %}{{ event.getName|e('html') }} - Joind.in{% endblock %}
     
 {% block body %}
     {% include 'Event/_common/event_header.html.twig' %}
@@ -48,7 +48,7 @@
         </div>
     </div>
 
-    <p>{{ event.getDescription|nl2br }}</p>
+    <p>{{ event.getDescription|e('html')|nl2br }}</p>
 
 
     {% if event.getLatitude != '0' and event.getLongitude != '0' %}


### PR DESCRIPTION
I don't really like this... but here it is.  Special characters are encoded and saved into the database; I can't see how you could change this without breaking too many other things.

So this decodes in the EventEntity and adds some escaping in the twig templates.