### PR TITLE
Fix issue with the sessions key overflowing the container

### DIFF
--- a/web/css/joindin.css
+++ b/web/css/joindin.css
@@ -13,6 +13,7 @@ body {
     padding-right: 10px;
 }
 .container-fluid {
+    max-width: 100%;
     padding-left: 10px;
     padding-right: 10px;
 }


### PR DESCRIPTION
## Features

- Fixed issue with the 'session key'

![screen shot 2015-10-03 at 11 23 57](https://cloud.githubusercontent.com/assets/13541397/10262512/7b0ba5c0-69c2-11e5-9c1c-30528d91df42.png)
 container-fluid overflowing when breakpoint > 1200px