### PR TITLE
Joindin 616 - Move "attending event" button and associated issues

### DIFF
--- a/app/templates/Event/_common/attending_string.html.twig
+++ b/app/templates/Event/_common/attending_string.html.twig
@@ -1,5 +1,5 @@
 {% if 0 != event.getAttendeeCount %}
-    | <span class="{{ event.getUrlFriendlyName|escape }}-attending-count">{{ event.getAttendeeCount|escape }}</span>
+    <span class="{{ event.getUrlFriendlyName|escape }}-attending-count">{{ event.getAttendeeCount|escape }}</span>
     <span class="{{ event.getUrlFriendlyName|escape }}-attending-string">
     {% if event.isPastEvent() %}
         attended

--- a/app/templates/Event/_common/event_header.html.twig
+++ b/app/templates/Event/_common/event_header.html.twig
@@ -13,7 +13,6 @@
 
                     at <a href="{{ urlFor('event-detail', {"friendly_name": event.getUrlFriendlyName}) }}#streetmap">{{ event.getLocation }}</a>
 
-                    {% include 'Event/_common/attending.html.twig' %}
                 </small>
             </h1>
         </div>

--- a/app/templates/Event/_common/summary.html.twig
+++ b/app/templates/Event/_common/summary.html.twig
@@ -42,6 +42,8 @@ set eventUrl = urlFor(
                     {% endif %}
                 </a>
 
+                |
+
                 {% include 'Event/_common/attending_string.html.twig' %}
 
                 {% include 'Event/_common/attending.html.twig' %}

--- a/app/templates/Event/details.html.twig
+++ b/app/templates/Event/details.html.twig
@@ -19,10 +19,7 @@
                         </div>
                     {% endif %}
 
-                    {% if event.getAttendeeCount %}
-                        {{ event.getAttendeeCount|escape }}</span> people
-                        {% if event.isPastEvent() %}attended{% else %}attending{% endif %}
-                    {% endif %}
+                    {% include 'Event/_common/attending_string.html.twig' %}
 
                     {% include 'Event/_common/attending.html.twig' %}
 

--- a/app/templates/Event/details.html.twig
+++ b/app/templates/Event/details.html.twig
@@ -24,6 +24,8 @@
                         {% if event.isPastEvent() %}attended{% else %}attending{% endif %}
                     {% endif %}
 
+                    {% include 'Event/_common/attending.html.twig' %}
+
                     <br>Host{% if event.hosts|length != 1 %}s{% endif %}:
                     {% for host in event.hosts %}
                         {% set comma = "" %}


### PR DESCRIPTION
The main focus of this PR is JOINDIN-616 but this lead to other issues being discovered.

The jquery associated with the "attending event" button (on the event page) did not function correctly due to missing elements.
This was fixed by using the existing template for the attending string.

The attending string template was altered to increase re-usability