### PR TITLE
Joindin 624

### DIFF
--- a/app/templates/Event/schedule-grid.html.twig
+++ b/app/templates/Event/schedule-grid.html.twig
@@ -75,7 +75,7 @@
                         {% endfor %}
 
                         {# skip keynote talks, as they will span all tracks (columns) #}
-                        {% if talk.type != "Keynote" %}
+                        {% if talk.type != "Keynote" and talk.type != "Social Event" %}
                             {% for track in day.tracks %}
                                 {% if track in actualTracks %}
                                     {# if track is a number, Twig won't allow this value
@@ -96,7 +96,7 @@
                         {% endif %}
 
                         {# if a talk has no tracks, or is a Keynote, span all tracks (columns) in table #}
-                        {% if talk.tracks|length == 0 or talk.type == "Keynote" %}
+                        {% if talk.tracks|length == 0 or talk.type == "Keynote" or talk.type == "Social Event" %}
                             <td class="{{ talk.getTypeClass }}" colspan={{ day.tracks|length }}>
                                 {% include '/Event/_common/schedule_cell.html.twig' %}
                             </td>

--- a/app/templates/Event/schedule-grid.html.twig
+++ b/app/templates/Event/schedule-grid.html.twig
@@ -75,7 +75,7 @@
                         {% endfor %}
 
                         {# skip keynote talks, as they will span all tracks (columns) #}
-                        {% if talk.type != "Keynote" and talk.type != "Social Event" %}
+                        {% if talk.type|lower != "keynote" and talk.type|lower != "social event" %}
                             {% for track in day.tracks %}
                                 {% if track in actualTracks %}
                                     {# if track is a number, Twig won't allow this value
@@ -96,7 +96,7 @@
                         {% endif %}
 
                         {# if a talk has no tracks, or is a Keynote, span all tracks (columns) in table #}
-                        {% if talk.tracks|length == 0 or talk.type == "Keynote" or talk.type == "Social Event" %}
+                        {% if talk.tracks|length == 0 or talk.type|lower == "keynote" or talk.type|lower == "social event" %}
                             <td class="{{ talk.getTypeClass }}" colspan={{ day.tracks|length }}>
                                 {% include '/Event/_common/schedule_cell.html.twig' %}
                             </td>


### PR DESCRIPTION
Alter template to make Social Events span across all tracks in the giid view in the same way Keynotes do.
Also alter talk.type comparisons to use lower case strings in the template as the api code seems to show "Social event" as a valid talk type yet the api is producing "Social Event" as an talk type for events

http://api.joind.in/v2.1/talks/15553

