### PR TITLE
Remove npm warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "repository": "",
   "author": "",
   "license": "BSD",
+  "private": true,
   "devDependencies": {
     "grunt": "0.4.2",
     "grunt-jsvalidate": "0.2.*"


### PR DESCRIPTION
When running `phing jsvalidate`, we get a couple of npm warnings related to being a good public repository citizen. As this is a private package, we set `private` to `true` to remove these unnecessary warnings.