### PR TITLE
Display session key as a single line in all sizes

### DIFF
--- a/app/templates/Event/schedule-grid.html.twig
+++ b/app/templates/Event/schedule-grid.html.twig
@@ -27,12 +27,14 @@
     <div>
         <label>Sessions Key</label>
 
-        <div class="container-fluid">
-            <div class="col-xs-12 col-md-2 col-md-offset-1 talk-type-keynote key">Keynote</div>
-            <div class="col-xs-12 col-md-2 talk-type-talk key">Talk</div>
-            <div class="col-xs-12 col-md-2 talk-type-workshop key">Workshop</div>
-            <div class="col-xs-12 col-md-2 talk-type-socialevent key">Social</div>
-            <div class="col-xs-12 col-md-2 talk-type-eventrelated key">Event Related</div>
+        <div class="row">
+            <div class="col-xs-12">
+                <div class="talk-type-keynote key">Keynote</div>
+                <div class="talk-type-talk key">Talk</div>
+                <div class="talk-type-workshop key">Workshop</div>
+                <div class="talk-type-socialevent key">Social</div>
+                <div class="talk-type-eventrelated key">Event Related</div>
+            </div>
         </div>
 
         {% for day in eventDays %}

--- a/web/css/joindin.css
+++ b/web/css/joindin.css
@@ -190,9 +190,19 @@ footer {
 }
 
 .key {
-    padding: 0.5em;
+    padding: 0.5em 5px;
     color: white;
     text-align: center;
+    position: relative;
+    min-height: 1px;
+    margin-bottom: 1px;
+    float: left;
+    width: auto;
+}
+@media (min-width: 435px) {
+.key {
+    padding: 0.5em 15px;
+}
 }
 
 .talk-type-talk {


### PR DESCRIPTION
Update the session key in grid view so that it always displays as a single line rather than resizing to a block of 5 at smaller window sizes. This makes the key far less intrusive.