### PR TITLE
Adding social meta for event image

### DIFF
--- a/app/templates/Event/details.html.twig
+++ b/app/templates/Event/details.html.twig
@@ -61,6 +61,7 @@
 {% endblock %}
 
 {% block extra_meta %}
+    {{ parent() }}
     <meta property="og:image" content="{{ event.getIcon|img_path("event_icons") }}">
     <meta name="twitter:image" content="{{ event.getIcon|img_path("event_icons") }}" data-page-subject="true">
     <meta name="twitter:card" content="photo" data-page-subject="true">

--- a/app/templates/Event/details.html.twig
+++ b/app/templates/Event/details.html.twig
@@ -61,7 +61,9 @@
 {% endblock %}
 
 {% block extra_meta %}
-    {{ parent() }}
+    <meta property="og:image" content="{{ event.getIcon|img_path("event_icons") }}">
+    <meta name="twitter:image" content="{{ event.getIcon|img_path("event_icons") }}" data-page-subject="true">
+    <meta name="twitter:card" content="photo" data-page-subject="true">
 {% endblock %}
 
 {% block extra_styles %}


### PR DESCRIPTION
By sharing links on social network sometimes the system picks up the wrong image. This tags forces the image that will appear in the post.

But this is still not good enough. The image size is very low and I think we have to add on other pages as well. I don't understand why we don't have (removed) the speaker's image in the talk details page.

We can add another metas too. ex:

```html
<meta name="twitter:site" content="@user">
<meta name="twitter:creator" content="@user">
<meta name="twitter:url" content="http://url.com">

<meta property="og:url" content="http://url.com">
<meta property="og:title" content="title">
<meta property="og:description" content="desc">

<meta name="description" content="desc">
```