### PR TITLE
Use OpenStreetMap over HTTPS

### DIFF
--- a/app/templates/Event/_common/form.html.twig
+++ b/app/templates/Event/_common/form.html.twig
@@ -192,7 +192,7 @@
         $(document).ready(function(){
             // Setup the click handler for the search button.
             $('#addr_search_button').click(function(){
-                $.getJSON('http://nominatim.openstreetmap.org/search?format=json&limit=5&q=' + $('#addr').val(), function(data) {
+                $.getJSON('https://nominatim.openstreetmap.org/search?format=json&limit=5&q=' + $('#addr').val(), function(data) {
                     var items = [];
 
                     var $addrSelector = $('#addr_selection');

--- a/web/js/joindin-map.js
+++ b/web/js/joindin-map.js
@@ -25,7 +25,7 @@
 
                     // Initialise the map
                     var map = new L.Map(mapDiv.attr('id'), {zoomControl: true});
-                    var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
                         osmAttribution = 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
                         osm = new L.TileLayer(osmUrl, {maxZoom: 18, attribution: osmAttribution});
                     map.setView(new L.LatLng(lat, lon), zoomLevel).addLayer(osm);


### PR DESCRIPTION
With m.joind.in running over HTTPS, the HTTP-only OpenStreetMap search wasn't working on the event submission page, and the loading of the map tiles over HTTP was showing as a warning in Chrome.