### PR TITLE
Only shows event short url if event_stub is set

### DIFF
--- a/app/templates/Event/details.html.twig
+++ b/app/templates/Event/details.html.twig
@@ -41,7 +41,9 @@
                 <div class="col-xs-12 col-sm-6">
                     Event Website: <a href="{{ event.getWebsiteAddress }}" rel="nofollow">{{ event.getWebsiteAddress }}</a> <i class="fa fa-external-link-square"></i>
                     <br>
-                    Short URL: <a href="{{ shortUrlForEvent(event.getStub) }}">{{ shortUrlForEvent(event.getStub) }}</a> <i class="fa fa-external-link-square"></i>
+                    {% if event.stub %}
+                        Short URL: <a href="{{ shortUrlForEvent(event.getStub) }}">{{ shortUrlForEvent(event.getStub) }}</a> <i class="fa fa-external-link-square"></i>
+                    {% endif %}
                     {% if event.getCfpStatus %}
                         <br>
                         Call for Papers:


### PR DESCRIPTION
Only shows event short url if event_stub is set

Per Akrabat's comment on JIRA setting to only show the URL if event_stub is set.  Open for other suggestions.

Closes #JOINDIN-593 fixed