### PR TITLE
New: Added compatibility route for /talk/view/<id> URL from web1

### DIFF
--- a/app/src/Talk/TalkController.php
+++ b/app/src/Talk/TalkController.php
@@ -21,6 +21,9 @@ class TalkController extends BaseController
         $app->get('/:talkId', array($this, 'quickById'))
             ->name('talk-quick-by-id')
             ->conditions(array('talkId' => '\d+'));
+        $app->get('/talk/view/:talkId', array($this, 'quickById'))
+            ->name('talk-by-id-web1')
+            ->conditions(array('talkId' => '\d+'));
     }
 
     public function index($eventSlug, $talkSlug)


### PR DESCRIPTION
From Jira:

> web1's long form talk urls of the format {{talk/view/15425}} need to work on web2

> This should be implemented with a new route that reuses the {{TalkController}}'s {{quickById}} action