### PR TITLE
Fixed Event Pending Description so the description body isn't wrapping around the buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ web/css/site.css
 web/js/site.js
 vendor/.git
 node_modules/
+.DS_Store

--- a/web/css/joindin.css
+++ b/web/css/joindin.css
@@ -395,7 +395,7 @@ table.schedule span.speaker a:hover {
 }
 
 .event.pending-event .description {
-    margin-left: 120px;
+    margin-left: 150px;
 }
 
 .event.pending-event form button {


### PR DESCRIPTION
I changed the margin-left from 120px to 150px in the joindin.css file. 