### PR TITLE
Move meta data to top on event pending page

### DIFF
--- a/app/templates/Event/pending.html.twig
+++ b/app/templates/Event/pending.html.twig
@@ -41,14 +41,6 @@
                         </h3>
 
                         <p class="meta">
-
-                        </p>
-
-                        <p class="wideOnly">
-                            {{ event.getDescription | nl2br }}
-                        </p>
-
-                        <p class="meta">
                             {{ dateRange(event.getStartDate, event.getEndDate, 'j M Y') }}
 
                             {% if event.getLocation %}
@@ -84,6 +76,9 @@
                                     {% endif %}
                                 </p>
                             {% endif %}
+                        </p>
+                        <p class="wideOnly">
+                            {{ event.getDescription | nl2br }}
                         </p>
                     </section>
                 </div>


### PR DESCRIPTION
The meta data (where, when, hosts, etc) needs to be above the
description now that the description may be many paragraphs long. This
makes it easier to assess whether to approve the even without having
to scroll.