### PR TITLE
Don't show the report comment link unless logged in

### DIFF
--- a/app/templates/_common/comment.html.twig
+++ b/app/templates/_common/comment.html.twig
@@ -36,7 +36,9 @@
                                 <a href="#comment-{{ comment.getCommentHash }}">{{ comment.getCommentDate|date('H:i \\o\\n j M Y', event.getFullTimezone) }}</a>
                                 <span class="hidden-xs">{% if comment.getCommentSource is not null %} (via {{ comment.getCommentSource }}){% endif %}</span>
                                 <br><br>
-                                <a href="/event/{{ event.getUrlFriendlyName }}{% if talk is not null %}/{{ talk.getUrlFriendlyTalkTitle }}{% endif %}/comments/{{ comment.getCommentHash }}/report">Report comment</a>
+                                {% if user %}
+                                    <a href="/event/{{ event.getUrlFriendlyName }}{% if talk is not null %}/{{ talk.getUrlFriendlyTalkTitle }}{% endif %}/comments/{{ comment.getCommentHash }}/report">Report comment</a>
+                                {% endif %}
                             </small>
                         </div>
                     </h3>


### PR DESCRIPTION
Users must be logged in to report a comment, so don't show the links to
users who aren't logged in.