### PR TITLE
Allow any length of venue name

### DIFF
--- a/app/src/Event/EventFormType.php
+++ b/app/src/Event/EventFormType.php
@@ -146,7 +146,7 @@ class EventFormType extends AbstractType
                 'text',
                 [
                     'label' => 'Venue name',
-                    'constraints' => [new Assert\NotBlank(), new Assert\Length(['min' => 3])],
+                    'constraints' => [new Assert\NotBlank()],
                 ]
             )
             ->add(


### PR DESCRIPTION
It turns out that some venue names are only two characters, so having validation that requires three characters is not helpful...