### PR TITLE
Show all events on user-hosted page

### DIFF
--- a/app/src/User/UserController.php
+++ b/app/src/User/UserController.php
@@ -410,7 +410,7 @@ class UserController extends BaseController
         $eventApi = $this->getEventApi();
         $hostedEventsCollection = $eventApi->getCollection(
             $user->getHostedEventsUri(),
-            ['verbose' => 'yes', 'resultsperpage' => 5]
+            ['verbose' => 'yes', 'resultsperpage' => 0]
         );
         if (!isset($hostedEventsCollection['events'])) {
             $this->application->redirect($this->application->urlFor('user-profile', ['username' => $username]));


### PR DESCRIPTION
With this change, `http://web2.dev.joind.in/user/[user]/hosted` should now show all events the user has ever hosted. Currently, it only shows 5 (e.g. https://m.joind.in/user/asgrim/hosted):

![asgrim](https://cloud.githubusercontent.com/assets/496145/11715187/d35a560e-9f37-11e5-9e7c-578cba61b5b6.png)
