### PR TITLE
Add ability to upload an event icon

### DIFF
--- a/app/src/Event/Constraint/ValidEventIcon.php
+++ b/app/src/Event/Constraint/ValidEventIcon.php
@@ -1,0 +1,15 @@
+<?php
+namespace Event\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+class ValidEventIcon extends Constraint
+{
+    public $groupname;
+    public $keyname;
+
+    public $message = 'The icon must be a square image';
+}

--- a/app/src/Event/Constraint/ValidEventIconValidator.php
+++ b/app/src/Event/Constraint/ValidEventIconValidator.php
@@ -1,0 +1,53 @@
+<?php
+namespace Event\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * @Annotation
+ */
+class ValidEventIconValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint)
+    {
+        $groupName = $constraint->groupname;
+        $keyName = $constraint->keyname;
+
+        $files = $_FILES;
+        if ($groupName) {
+            if (!isset($_FILES[$groupName])) {
+                return;
+            }
+            $files = $_FILES[$groupName];
+        }
+
+        if (isset($files['error']) && isset($files['error'][$keyName])
+            && $files['error'][$keyName] === UPLOAD_ERR_OK) {
+            $filename = $files['name'][$keyName];
+            // we have a file - is it valid?
+            $contents = file_get_contents($files['tmp_name'][$keyName]);
+            $image = @imagecreatefromstring($contents);
+            if ($image === false) {
+                 $this->context->buildViolation("'%filename%' is not a recognised image file")
+                    ->setParameter('%filename%', $filename)
+                    ->addViolation();
+                return;
+            }
+
+            $width = imagesx($image);
+            $height = imagesy($image);
+            if ($width !== $height) {
+                imagedestroy($image);
+                 $this->context->buildViolation("'%filename%' is not a square image")
+                    ->setParameter('%filename%', $filename)
+                    ->addViolation();
+                return;
+            }
+
+            // we got here - image is fine.
+            imagedestroy($image);
+
+        }
+    }
+}

--- a/app/src/Event/EventApi.php
+++ b/app/src/Event/EventApi.php
@@ -292,6 +292,30 @@ class EventApi extends BaseApi
     }
 
     /**
+     * Upload event icon
+     *
+     * @param  string $event_uri event's URI
+     * @param  string $fileData  array of 'image' (base64 encoded string of image file contents)
+     *                           and 'type' (mimetype of image)
+     * @return boolean
+     */
+    public function uploadIcon($event_uri, $fileData)
+    {
+        $uri = $event_uri . '/icon';
+
+        $data['type'] = $fileData['type'];
+        $data['image'] = $fileData['image'];
+
+        list ($status, $result, $headers) = $this->apiPut($uri, $data);
+
+        if ($status == 204) {
+            return true;
+        }
+
+        throw new \Exception($result);
+    }
+
+    /**
      * Returns a response array containing an 'events' and 'pagination' element.
 
      * Each event in this response is also stored in the cache so that a relation

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -470,10 +470,9 @@ class EventController extends BaseController
             $form->submit($request->post($form->getName()));
 
             if ($form->isValid()) {
-                $event = $this->editEventUsingForm($form, $event);
-
-                if ($event instanceof EventEntity) {
-                    $this->redirectToDetailPage($event->getUrlFriendlyName());
+                $result = $this->editEventUsingForm($form, $event);
+                if ($result instanceof EventEntity) {
+                    $this->redirectToDetailPage($result->getUrlFriendlyName());
                 }
             }
         }
@@ -602,7 +601,42 @@ class EventController extends BaseController
             );
         }
 
+        try {
+            $fileData = $this->getUploadedFileData($_FILES['event'], 'new_icon');
+            if ($fileData) {
+                $eventApi->uploadIcon($values['uri'], $fileData);
+            }
+        } catch (\Exception $e) {
+            $result = false;
+            $error = $e->getMessage();
+            $messages = json_decode($error);
+            if ($messages) {
+                $error = implode(', ', $messages);
+            }
+            $form->addError(
+                new FormError("An error occurred while uploading your event icon: $error")
+            );
+        }
+
         return $result;
+    }
+
+    /**
+     * Retrieve the uploaded file data for $key.
+     *
+     * @param  string $key
+     * @return array|false
+     */
+    private function getUploadedFileData($files, $key)
+    {
+        if (isset($files['error'][$key]) && $files['error'][$key] == UPLOAD_ERR_OK) {
+            $data = file_get_contents($files['tmp_name'][$key]);
+            $fileData['image'] = base64_encode($data);
+            $fileData['type'] = $files['type'][$key];
+
+            return $fileData;
+        }
+        return false;
     }
 
     protected function getEventApi()

--- a/app/src/Event/EventEntity.php
+++ b/app/src/Event/EventEntity.php
@@ -522,4 +522,12 @@ class EventEntity
     {
         return $this->data->approval_uri;
     }
+
+    /**
+     * Used by the edit form
+     */
+    public function getNewIcon()
+    {
+        return null;
+    }
 }

--- a/app/src/Event/EventFormType.php
+++ b/app/src/Event/EventFormType.php
@@ -165,6 +165,19 @@ class EventFormType extends AbstractType
                     'attr' => ['readonly' => 'readonly'],
                 ]
             )
+            ->add(
+                'new_icon',
+                'file',
+                [
+                    'data_class' => null,
+                    'label' => 'Upload new icon',
+                    'required' => false,
+                    'attr'=> [
+                        'class'=>'file',
+                    ],
+                    'constraints' => [new Constraint\ValidEventIcon(['groupname' => 'event', 'keyname'=>'new_icon'])],
+                ]
+            )
         ;
     }
 

--- a/app/src/Middleware/ValidationMiddleware.php
+++ b/app/src/Middleware/ValidationMiddleware.php
@@ -11,6 +11,7 @@ use Symfony\Component\Validator\ConstraintValidatorFactory;
 use Symfony\Component\Validator\Mapping\ClassMetadataFactory;
 use Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader;
 use Symfony\Component\Validator\Validator;
+use Symfony\Component\Validator\Validation;
 
 /**
  * In this middleware we create the validation services as provided by Symfony and register it as service in the
@@ -77,11 +78,14 @@ class ValidationMiddleware extends Middleware
      */
     public function createValidator()
     {
-        return new Validator(
-            new ClassMetadataFactory(new StaticMethodLoader()),
-            new ConstraintValidatorFactory($this->app, array()),
-            $this->getTranslator()
-        );
+        $validator = Validation::createValidatorBuilder()
+            ->setMetadataFactory(new ClassMetadataFactory(new StaticMethodLoader()))
+            ->setConstraintValidatorFactory(new ConstraintValidatorFactory($this->app, array()))
+            ->setTranslator($this->getTranslator())
+            ->setApiVersion(Validation::API_VERSION_2_5)
+            ->getValidator();
+
+        return $validator;
     }
 
     /**

--- a/app/src/View/Filters.php
+++ b/app/src/View/Filters.php
@@ -3,12 +3,22 @@ namespace View\Filters;
 
 use Twig_Environment;
 use Twig_Filter_Function;
+use Slim\Slim;
 
-function initialize(Twig_Environment $env)
+function initialize(Twig_Environment $env, Slim $app)
 {
     $env->addFilter(
         'img_path',
-        new Twig_Filter_Function('\View\Filters\img_path', ['needs_environment' => true])
+        new Twig_Filter_Function(
+            function ($env, $suffix, $infix) use ($app) {
+                $base_url = $app->config('image_base_url');
+                if (!$base_url) {
+                    $base_url = 'https://joind.in/inc';
+                }
+                return \View\Filters\img_path($env, $suffix, $infix, $base_url);
+            },
+            ['needs_environment' => true]
+        )
     );
     $env->addFilter(
         'link',
@@ -20,7 +30,7 @@ function initialize(Twig_Environment $env)
     $env->addFilter('format_date', new Twig_Filter_Function('\View\Filters\format_date'));
 }
 
-function img_path($env, $suffix, $infix)
+function img_path($env, $suffix, $infix, $base_url)
 {
     if (!$suffix && $infix = 'event_icons') {
         $suffix = 'none.png';
@@ -34,7 +44,7 @@ function img_path($env, $suffix, $infix)
         return $uri . $path;
     }
 
-    return 'https://joind.in/inc' .$path;
+    return $base_url .$path;
 }
 
 function format_date($date)

--- a/app/templates/Event/_common/form.html.twig
+++ b/app/templates/Event/_common/form.html.twig
@@ -44,9 +44,13 @@
 
             {% if event.name %}
             <fieldset class="col-offset-sm-6 col-sm-6 event">
-                <p>An event's icon must be a square image.</p>
                 <legend>Icon</legend>
-                {{ form_row(form.new_icon) }}
+                <div class="logo text-center">
+                    <img src="{{ event.getIcon|img_path("event_icons") }}">
+                </div>
+                <div>
+                    {{ form_row(form.new_icon) }}
+                </div>
             </fieldset>
             {% endif %}
         </div>

--- a/app/templates/Event/_common/form.html.twig
+++ b/app/templates/Event/_common/form.html.twig
@@ -41,6 +41,14 @@
                 </div>
                 {{ form_row(form.cfp_url) }}
             </fieldset>
+
+            {% if event.name %}
+            <fieldset class="col-offset-sm-6 col-sm-6 event">
+                <p>An event's icon must be a square image.</p>
+                <legend>Icon</legend>
+                {{ form_row(form.new_icon) }}
+            </fieldset>
+            {% endif %}
         </div>
         <div class="row">
             <fieldset class="col-sm-12" class="location">

--- a/app/templates/_common/joindin_form_div_layout.html.twig
+++ b/app/templates/_common/joindin_form_div_layout.html.twig
@@ -27,14 +27,18 @@ render the errors after the widget. #}
 
 {# Elements need a form-control class #}
 {% block widget_attributes %}
-{% set attr = attr|merge({'class': (attr.class|default('') ~ ' form-control')|trim}) %}
+{% if attr.class is not defined %}
+    {% set attr = attr|merge({'class': 'form-control'}) %}
+{% endif %}
 {{ parent() }}
 {% endblock widget_attributes %}
 
 {# Labels need a control-label class #}
 {% block form_label %}
 {% if label is not sameas(false) %}
-    {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' control-label')|trim}) %}
+    {% if label_attr.class is not defined %}
+        {% set label_attr = label_attr|merge({'class': 'control-label'}) %}
+    {% endif %}
 {% endif %}
 {{ parent() }}
 {% endblock form_label %}

--- a/config/config.php.dist
+++ b/config/config.php.dist
@@ -19,6 +19,7 @@ $config = array(
         'twig' => array(
             // set to the folder name to cache into, or false to disable
             'cache' => false
-        )
+        ),
+        'image_base_url' => 'http://dev.joind.in/inc',
     ),
 );


### PR DESCRIPTION
Add icon upload to the edit event form.

Also enable configuration of the base URL from which to serve images, so that we can see that it's working in the development environment (if you change you config.php as per the dist file).

This is the web2 part of [JOINDIN-530](https://joindin.jira.com/browse/JOINDIN-530).

Note: only merge this if https://github.com/joindin/joindin-api/pull/289 is accepted! Also, this PR should be updated to remove the `image_base_url` config setting if https://github.com/joindin/joindin-api/pull/292 is accepted.