### PR TITLE
Use API if we can't find event in DB in quickById()

### DIFF
--- a/app/src/Talk/TalkController.php
+++ b/app/src/Talk/TalkController.php
@@ -118,7 +118,13 @@ class TalkController extends BaseController
 
         $event = $eventDb->load('uri', $talk->getEventUri());
         if (!$event) {
-            return \Slim\Slim::getInstance()->notFound();
+            // load from API as not in cache
+            $eventApi = $this->getEventApi();
+            $eventEntity = $eventApi->getEvent($talk->getEventUri());
+            if (!$eventEntity) {
+                return \Slim\Slim::getInstance()->notFound();
+            }
+            $event['url_friendly_name'] = $eventEntity->getUrlFriendlyName();
         }
 
         $this->application->redirect(


### PR DESCRIPTION
It's possible with a direct link that the event isn't in the Redis cache, so grab from the API if this happens.