### PR TITLE
Add catchall on old user URL

### DIFF
--- a/app/src/User/UserController.php
+++ b/app/src/User/UserController.php
@@ -43,7 +43,7 @@ class UserController extends BaseController
         $app->get('/user/:username/comments', array($this, 'profileComments'))->name('user-profile-comments');
         $app->map('/user/:username/edit', array($this, 'profileEdit'))
             ->via('GET', 'POST')->name('user-profile-edit');
-        $app->get('/user/view/:userId', array($this, 'redirectFromId'))
+        $app->get('/user/view/:userId(/:others+)', array($this, 'redirectFromId'))
             ->name('user-redirect-from-id')
             ->conditions(array('userId' => '\d+'));
     }

--- a/app/src/User/UserController.php
+++ b/app/src/User/UserController.php
@@ -43,7 +43,7 @@ class UserController extends BaseController
         $app->get('/user/:username/comments', array($this, 'profileComments'))->name('user-profile-comments');
         $app->map('/user/:username/edit', array($this, 'profileEdit'))
             ->via('GET', 'POST')->name('user-profile-edit');
-        $app->get('/user/view/:userId(/:others+)', array($this, 'redirectFromId'))
+        $app->get('/user/view/:userId(/:extra+)', array($this, 'redirectFromId'))
             ->name('user-redirect-from-id')
             ->conditions(array('userId' => '\d+'));
     }


### PR DESCRIPTION
URLs of the form `/user/view/24206` may have additional segments that were valid on web1. We want to match and ignore as we don't use them, but do want them to redirect to the user's profile page.