### PR TITLE
On user talks page, link comment count to talk

### DIFF
--- a/app/templates/User/profile-talks.html.twig
+++ b/app/templates/User/profile-talks.html.twig
@@ -53,7 +53,7 @@
                                     </span>
 
                                     <span class="comment-count">
-                                        <a href="{{ urlForTalk(event.getUrlFriendlyName, talk.getUrlFriendlyTalkTitle) }}">{{ talk.commentCount }}</a>
+                                        <a href="{{ urlFor('talk', {'eventSlug': event.url_friendly_name, 'talkSlug': talk.getUrlFriendlyTalkTitle }) }}"> {{ talk.commentCount }}</a>
                                     </span>
                                 </div>
 


### PR DESCRIPTION
The event part of the URL was missing and so the links didn't work