### PR TITLE
Serve new rating images at old rating image URLs

### DIFF
--- a/web/.htaccess
+++ b/web/.htaccess
@@ -8,6 +8,8 @@ RewriteEngine On
 #
 # RewriteBase /
 
+RewriteRule ^inc/img/rating-(\d)\.gif$ img/avg-rating-$1.png [L]
+
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_URI} ^(.+)/$
 RewriteRule ^(.+)/$  /$1 [R=301,L]


### PR DESCRIPTION
We used to have images such as /inc/img/rating-4.gif which are used by our js widgets and also by other people using joindin data on their blogs.  This rewrite rule returns our new rating images at those existing URLs.