### PR TITLE
Allow clearing of CfP dates when editing an event

### DIFF
--- a/app/src/Event/EventApi.php
+++ b/app/src/Event/EventApi.php
@@ -274,7 +274,7 @@ class EventApi extends BaseApi
                 $data[$dateField] = $data[$dateField]->format('c');
             }
             if (isset($data[$dateField])) {
-                if (!strtotime($data[$dateField])) {
+                if (!empty($data[$dateField]) && !strtotime($data[$dateField])) {
                     unset($data[$dateField]);
                 }
             }


### PR DESCRIPTION
An empty date field is valid when we want to clear it.