### PR TITLE
Return false when talk doesn't exist

### DIFF
--- a/app/src/Talk/TalkApi.php
+++ b/app/src/Talk/TalkApi.php
@@ -112,6 +112,9 @@ class TalkApi extends BaseApi
 
         $collection = (array)json_decode($this->apiGet($talk_uri));
 
+        if (!isset($collection['talks'])) {
+            return false;
+        }
         $talk = new TalkEntity($collection['talks'][0]);
         $this->talkDb->save($talk);
 


### PR DESCRIPTION
If the talk doesn't exist in the API, return false rather than cause an exception error.

Fixes https://joind.in/talk/view/2721 so that it returns a 404 rather than a 500.