### PR TITLE
Send a 410 for feed URLs

### DIFF
--- a/web/.htaccess
+++ b/web/.htaccess
@@ -10,6 +10,10 @@ RewriteEngine On
 
 RewriteRule ^inc/img/rating-(\d)\.gif$ img/avg-rating-$1.png [L]
 
+# Send 410 for /feed*
+RewriteEngine on
+RewriteRule ^feed - [NC,G,L]
+
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_URI} ^(.+)/$
 RewriteRule ^(.+)/$  /$1 [R=301,L]

--- a/web/.htaccess
+++ b/web/.htaccess
@@ -11,7 +11,6 @@ RewriteEngine On
 RewriteRule ^inc/img/rating-(\d)\.gif$ img/avg-rating-$1.png [L]
 
 # Send 410 for /feed*
-RewriteEngine on
 RewriteRule ^feed - [NC,G,L]
 
 RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
We don't support /feed URLs from the legacy site any more, so inform clients that they are gone.