### PR TITLE
Enable listing of previous events

### DIFF
--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -53,31 +53,25 @@ class EventController extends BaseController
 
     public function index()
     {
-        $page = $this->application->request()->get('page');
-        if ($page === null) {
-            // if page is not set, then do not set $start so that the API will return
-            // the first page of events where at least one event is in the future
-            $page = 1;
-            $start = null;
-        } else {
-            $page = ((int)$page === 0) ? 1 : $page;
-            $start = ($page -1) * $this->itemsPerPage;
-        }
+        $start = $this->application->request()->get('start');
 
         $eventApi = $this->getEventApi();
         $events = $eventApi->getEvents($this->itemsPerPage, $start, 'all');
         if ($start === null) {
-            // Find out the page number that has been sent back to us by the API - if
-            // we can't work it out, assume it is page 1
+            // Find out the start number that has been sent back to us by the API - if
+            // we can't work it out, assume it is 0
             $start = 0;
-            $page = 1;
             if (isset($events['pagination'])) {
                 parse_str(parse_url($events['pagination']->this_page, PHP_URL_QUERY), $parts);
                 if (isset($parts['start'])) {
                     $start = $parts['start'];
-                    $page = (int)($start / $this->itemsPerPage) + 1;
                 }
             }
+        }
+        $nextStart = $start + $this->itemsPerPage;
+        $prevStart = $start - $this->itemsPerPage;
+        if ($prevStart < 0) {
+            $prevStart = 0;
         }
 
         $cfpEvents = $eventApi->getEvents(4, 0, 'cfp', true);
@@ -85,7 +79,8 @@ class EventController extends BaseController
         $this->render(
             'Event/index.html.twig',
             array(
-                'page' => $page,
+                'prevStart' => $prevStart,
+                'nextStart' => $nextStart,
                 'cfp_events' => $cfpEvents,
                 'events' => $events
             )

--- a/app/templates/Event/_common/event_pagination.html.twig
+++ b/app/templates/Event/_common/event_pagination.html.twig
@@ -1,0 +1,31 @@
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-xs-12 text-center">
+            <ul class="pagination">
+                {% if pagination.prev_page %}
+                    <li>
+                        <a href="?start={{ prevStart }}{% if keyword %}&amp;keyword={{ keyword }}{% endif %}{% if tag %}&amp;tag={{ tag }}{% endif %}">
+                            <i class="fa fa-arrow-circle-o-left"></i> Previous
+                        </a>
+                    </li>
+                {% else %}
+                    <li class="disabled">
+                        <a href="javascript:"><i class="fa fa-arrow-circle-o-left"></i> Prev<span class="hidden-xs">ious</span></a>
+                    </li>
+                {% endif %}
+                <!-- <li class="current hidden&#45;xs"><a href="#">Page {{ page }}</a></li> -->
+                {% if pagination.next_page and pagination.count >= 10 %}
+                    <li>
+                        <a href="?start={{ nextStart }}{% if keyword %}&amp;keyword={{ keyword }}{% endif %}{% if tag %}&amp;tag={{ tag }}{% endif %}">
+                            Next <i class="fa fa-arrow-circle-o-right"></i>
+                        </a>
+                    </li>
+                {% else %}
+                    <li class="disabled">
+                        <a href="javascript:">Next <i class="fa fa-arrow-circle-o-right"></i></a>
+                    </li>
+                {% endif %}
+            </ul>
+        </div>
+    </div>
+</div>

--- a/app/templates/Event/_common/event_pagination.html.twig
+++ b/app/templates/Event/_common/event_pagination.html.twig
@@ -4,7 +4,7 @@
             <ul class="pagination">
                 {% if pagination.prev_page %}
                     <li>
-                        <a href="?start={{ prevStart }}{% if keyword %}&amp;keyword={{ keyword }}{% endif %}{% if tag %}&amp;tag={{ tag }}{% endif %}">
+                        <a href="{{ urlFor("events-index") }}{% if (page - 1) != 0 %}?page={{ page - 1 }}{% endif %}">
                             <i class="fa fa-arrow-circle-o-left"></i> Previous
                         </a>
                     </li>
@@ -13,10 +13,10 @@
                         <a href="javascript:"><i class="fa fa-arrow-circle-o-left"></i> Prev<span class="hidden-xs">ious</span></a>
                     </li>
                 {% endif %}
-                <!-- <li class="current hidden&#45;xs"><a href="#">Page {{ page }}</a></li> -->
-                {% if pagination.next_page and pagination.count >= 10 %}
+
+                {% if pagination.next_page and (pagination.count >= 10 or page < 0)  %}
                     <li>
-                        <a href="?start={{ nextStart }}{% if keyword %}&amp;keyword={{ keyword }}{% endif %}{% if tag %}&amp;tag={{ tag }}{% endif %}">
+                        <a href="{{ urlFor("events-index") }}{% if (page + 1) != 0 %}?page={{ page + 1 }}{% endif %}">
                             Next <i class="fa fa-arrow-circle-o-right"></i>
                         </a>
                     </li>

--- a/app/templates/Event/index.html.twig
+++ b/app/templates/Event/index.html.twig
@@ -19,7 +19,7 @@
             {% include 'Event/_common/summary.html.twig' %}
         {% endfor %}
     </div>
-    {% include '_common/pagination.html.twig' with {'pagination': events.pagination} %}
+    {% include 'Event/_common/event_pagination.html.twig' with {'pagination': events.pagination} %}
 {% endblock %}
 
 {% block extraAside %}

--- a/app/templates/Event/index.html.twig
+++ b/app/templates/Event/index.html.twig
@@ -10,7 +10,7 @@
         </ul>
     </nav>
     {% endif %}
-    <h1 class="title">Upcoming events</h1>
+    <h1 class="title">Events</h1>
     {% if flash.getMessages.message %}
         <div class="alert alert-success">{{ flash.getMessages.message|nl2br }}</div>
     {% endif %}


### PR DESCRIPTION
Use the API's "all" filter for the events list so that we can go backwards as well as forwards

If the page query parameter is not set, then do not pass a start number to the API's so that the event's "all" filter will return the first page of events where at least one event is in the future. That is, we get a list of events positioned at "now".

In this case, we have to work out the current page number ourselves, which we do by looking at the this_page meta field which contains the correct start parameter.

Depends on https://github.com/joindin/joindin-api/pull/295

Fixes [JOINDIN-499](https://joindin.jira.com/browse/JOINDIN-499)