### PR TITLE
Highlight current submenu item on event page

### DIFF
--- a/app/src/View/Functions.php
+++ b/app/src/View/Functions.php
@@ -37,6 +37,10 @@ function initialize(Twig_Environment $env, Slim $app)
         return $url;
     }));
 
+    $env->addFunction(new Twig_SimpleFunction('getCurrentRoute', function () use ($app) {
+        return $app->router->getCurrentRoute()->getName();
+    }));
+
     $env->addFunction(new Twig_SimpleFunction('getCurrentUrl', function () {
         return $_SERVER['REQUEST_URI'];
     }));

--- a/app/templates/Event/_common/event_header.html.twig
+++ b/app/templates/Event/_common/event_header.html.twig
@@ -19,12 +19,23 @@
     </div>
     <nav class="page-nav">
         <ul class="nav nav-pills">
-            <li><a href="{{ urlFor('event-detail', {"friendly_name": event.getUrlFriendlyName}) }}">Details</a></li>
-            <li><a href="{{ urlFor('event-schedule', {"friendly_name": event.getUrlFriendlyName}) }}">Schedule</a></li>
-            <li><a href="{{ urlFor('event-comments', {"friendly_name": event.getUrlFriendlyName}) }}">Event comments</a></li>
-            <li><a href="{{ urlFor('event-talk-comments', {"friendly_name": event.getUrlFriendlyName}) }}">Talk comments</a></li>
+            {% set event_sub_menu = [
+                {"route":"event-detail", "name":"Details", "active_match": ['event-default', 'event-detail']},
+                {"route":"event-schedule", "name":"Schedule", "active_match": ['event-schedule-list', 'event-schedule-grid']},
+                {"route":"event-comments", "name":"Event comments", "active_match": ['event-comments']},
+                {"route":"event-talk-comments", "name":"Talk comments", "active_match": ['event-talk-comments']}
+            ] %}
+
+            {% for item in event_sub_menu %}
+            <li class="{% if getCurrentRoute() in item.active_match %}active{% endif %}">
+                <a href="{{ urlFor(item.route, {"friendly_name": event.getUrlFriendlyName}) }}">{{ item.name }}</a>
+            </li>
+            {% endfor %}
+
             {% if event.getCanEdit %}
-            <li><a href="{{ urlFor('event-edit', {"friendly_name": event.getUrlFriendlyName}) }}">Edit</a></li>
+            <li class="{% if getCurrentRoute() == 'event-edit' %}active{% endif %}">
+                <a href="{{ urlFor('event-edit', {"friendly_name": event.getUrlFriendlyName}) }}">Edit</a>
+            </li>
             {% endif %}
         </ul>
     </nav>

--- a/app/templates/Event/_common/event_header.html.twig
+++ b/app/templates/Event/_common/event_header.html.twig
@@ -20,8 +20,9 @@
     <nav class="page-nav">
         <ul class="nav nav-pills">
             {% set event_sub_menu = [
-                {"route":"event-detail", "name":"Details", "active_match": ['event-default', 'event-detail']},
-                {"route":"event-schedule", "name":"Schedule", "active_match": ['event-schedule-list', 'event-schedule-grid']},
+                {"route":"event-detail", "name":"Details", "active_match": ['event-detail']},
+                {"route":"event-schedule", "name":"Schedule",
+                    "active_match": ['event-default', 'event-schedule-list', 'event-schedule-grid']},
                 {"route":"event-comments", "name":"Event comments", "active_match": ['event-comments']},
                 {"route":"event-talk-comments", "name":"Talk comments", "active_match": ['event-talk-comments']}
             ] %}

--- a/web/css/joindin.css
+++ b/web/css/joindin.css
@@ -72,6 +72,16 @@ form.navbar-form {
     margin-top: 10px;
 }
 
+.nav-pills > li.active > a, .nav-pills > li.active > a:focus {
+    font-weight: bold;
+    background-color: #fff;
+    color: #428bca;
+}
+.nav-pills > li.active > a:hover {
+    background-color: #eee;
+    color: #428bca;
+}
+
 h1 {
     border-bottom: 1px solid #d7dcdf;
     color: #000;


### PR DESCRIPTION
Expose the current route to Twig and then use this to set the active class for the submenu navigation on the event page. Override the default active style to simply bold the current submenu item.

<s>Note that this will need changing if #321 is merged.</s>