### PR TITLE
Display the event's schedule by default

### DIFF
--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -152,14 +152,12 @@ class EventController extends BaseController
             return Slim::getInstance()->notFound();
         }
 
-        $now = new \DateTime();
-        $startDate = new \DateTime($event->getStartDate());
-        $endDate = new \DateTime($event->getEndDate());
-        if ($now >= $startDate && $now <= $endDate->add(new \DateInterval('P2D'))) {
-            return $this->schedule($friendly_name);
-        } else {
-            return $this->details($friendly_name);
+        $action = 'scheduleList';
+        if (isset($_COOKIE['schedule-view']) && $_COOKIE['schedule-view'] == 'grid') {
+            $action = 'scheduleGrid';
         }
+
+        return $this->$action($friendly_name);
     }
 
     public function details($friendly_name)

--- a/app/templates/Event/schedule-grid.html.twig
+++ b/app/templates/Event/schedule-grid.html.twig
@@ -12,6 +12,10 @@
 {% block body %}
     {% include 'Event/_common/event_header.html.twig' %}
 
+    {# Display the first paragraph of the description above the schedule #}
+    {% set paragraphs = event.getDescription | split("\n") %}
+    <p>{{ paragraphs[0] }}</p>
+
     <div class="row">
         <div class="col-xs-6">
             <h2>Schedule</h2>

--- a/app/templates/Event/schedule-grid.html.twig
+++ b/app/templates/Event/schedule-grid.html.twig
@@ -24,6 +24,7 @@
         </div>
     </div>
 
+    {% if eventDays %}
     <div>
         <label>Sessions Key</label>
 
@@ -133,4 +134,8 @@
         </table>
         {% endfor %}
     </div>
+    {% else %}
+    <p>This event does not have a schedule.</p>
+    {% endif %}
+
 {% endblock %}

--- a/app/templates/Event/schedule-list.html.twig
+++ b/app/templates/Event/schedule-list.html.twig
@@ -23,6 +23,7 @@
             </div>
         </div>
     </div>
+
     {% if agenda|length %}
     <div class="agenda">
         {% for date,days in agenda %}
@@ -88,6 +89,8 @@
             </table>
         {% endfor %}
     </div>
+    {% else %}
+    <p>This event does not have a schedule.</p>
     {% endif %}
 
 {% endblock %}

--- a/app/templates/Event/schedule-list.html.twig
+++ b/app/templates/Event/schedule-list.html.twig
@@ -12,6 +12,10 @@
 {% block body %}
     {% include 'Event/_common/event_header.html.twig' %}
 
+    {# Display the first paragraph of the description above the schedule #}
+    {% set paragraphs = event.getDescription | split("\n") %}
+    <p>{{ paragraphs[0] }}</p>
+
     <div class="row">
         <div class="col-xs-6">
             <h2>Schedule</h2>


### PR DESCRIPTION
As reported by Eli White, when first viewing an event, display the  schedule rather than the details page. Also, update the schedule page with the first paragraph of the description for context and a message if there are no talks for this event.

Note that the work in #320 will need updating when this is merged.