### PR TITLE
Display reported comments

### DIFF
--- a/app/src/Event/EventApi.php
+++ b/app/src/Event/EventApi.php
@@ -3,6 +3,7 @@ namespace Event;
 
 use Application\BaseApi;
 use Talk\TalkCommentEntity;
+use Talk\TalkCommentReportEntity;
 use User\UserApi;
 
 class EventApi extends BaseApi
@@ -398,4 +399,31 @@ class EventApi extends BaseApi
         }
         throw new \Exception("Failed to reject event: " . $result);
     }
+
+    public function getReportedEventComments($comment_uri)
+    {
+        $response = json_decode($this->apiGet($comment_uri));
+
+        $reports = [];
+
+        foreach ($response->reports as $item) {
+            $reports[] = new EventCommentReportEntity($item);
+        }
+
+        return $reports;
+    }
+
+    public function getReportedTalkComments($comment_uri)
+    {
+        $response = json_decode($this->apiGet($comment_uri));
+
+        $reports = [];
+
+        foreach ($response->reports as $item) {
+            $reports[] = new TalkCommentReportEntity($item);
+        }
+
+        return $reports;
+    }
+
 }

--- a/app/src/Event/EventApi.php
+++ b/app/src/Event/EventApi.php
@@ -425,5 +425,4 @@ class EventApi extends BaseApi
 
         return $reports;
     }
-
 }

--- a/app/src/Event/EventCommentReportEntity.php
+++ b/app/src/Event/EventCommentReportEntity.php
@@ -1,0 +1,38 @@
+<?php
+namespace Event;
+
+class EventCommentReportEntity
+{
+    private $data;
+    private $comment;
+
+    /**
+     * Create new EventCommentReportEntity
+     *
+     * @param Object $data Model data retrieved from API
+     */
+    public function __construct($data)
+    {
+        // should contain a comment
+        if ($data->comment) {
+            $this->comment = new EventCommentEntity($data->comment);
+            unset($data->comment);
+        }
+        $this->data = $data;
+    }
+
+    public function getComment()
+    {
+        return $this->comment;
+    }
+
+    public function getReportingDate()
+    {
+        return $this->data->reporting_date;
+    }
+
+    public function getReportingUser()
+    {
+        return $this->data->reporting_user_username;
+    }
+}

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -48,6 +48,7 @@ class EventController extends BaseController
         $app->get('/event/view/:eventId(/:extra+)', array($this, 'redirectFromId'))
             ->name('event-redirect-from-id')
             ->conditions(array('eventId' => '\d+'));
+        $app->get('/event/:friendly_name/reported-comments', array($this, 'reportedComments'))->name("event-reported-comments");
     }
 
     public function index()
@@ -696,6 +697,39 @@ class EventController extends BaseController
         }
 
         $this->application->response()->body(json_encode(array('success' => $result)));
+    }
+
+    public function reportedComments($friendly_name)
+    {
+        $eventApi = $this->getEventApi();
+        $event = $eventApi->getByFriendlyUrl($friendly_name);
+
+        if ($event) {
+            if (! $event->getCanEdit()) {
+                $this->redirectToDetailPage($event->getUrlFriendlyName());
+            }
+
+            $eventComments = $eventApi->getReportedEventComments(
+                $event->getReportedEventCommentsUri()
+            );
+
+            $talkComments = $eventApi->getReportedTalkComments(
+                $event->getReportedTalkCommentsUri()
+            );
+
+            var_dump($eventComments);
+            $this->render(
+                'Event/reported-comments.html.twig',
+                array(
+                    'event' => $event,
+                    'eventComments' => $eventComments,
+                    'talkComments'  => $talkComments,
+                )
+            );
+        } else {
+            $events_url = $this->application->urlFor("events-index");
+            $this->application->redirect($events_url);
+        }
     }
 
     /**

--- a/app/src/Event/EventEntity.php
+++ b/app/src/Event/EventEntity.php
@@ -522,4 +522,22 @@ class EventEntity
     {
         return $this->data->approval_uri;
     }
+
+    public function getReportedEventCommentsUri()
+    {
+        if (isset($this->data->reported_comments_uri)) {
+            return $this->data->reported_comments_uri;
+        } else {
+            return false;
+        }
+    }
+
+    public function getReportedTalkCommentsUri()
+    {
+        if (isset($this->data->reported_talk_comments_uri)) {
+            return $this->data->reported_talk_comments_uri;
+        } else {
+            return false;
+        }
+    }
 }

--- a/app/src/Talk/TalkCommentReportEntity.php
+++ b/app/src/Talk/TalkCommentReportEntity.php
@@ -36,4 +36,3 @@ class TalkCommentReportEntity
         return $this->data->reporting_user_username;
     }
 }
-

--- a/app/src/Talk/TalkCommentReportEntity.php
+++ b/app/src/Talk/TalkCommentReportEntity.php
@@ -1,0 +1,39 @@
+<?php
+namespace Talk;
+
+class TalkCommentReportEntity
+{
+    private $data;
+    private $comment;
+
+    /**
+     * Create new TalkCommentReportEntity
+     *
+     * @param Object $data Model data retrieved from API
+     */
+    public function __construct($data)
+    {
+        // should contain a comment
+        if ($data->comment) {
+            $this->comment = new TalkCommentEntity($data->comment);
+            unset($data->comment);
+        }
+        $this->data = $data;
+    }
+
+    public function getComment()
+    {
+        return $this->comment;
+    }
+
+    public function getReportingDate()
+    {
+        return $this->data->reporting_date;
+    }
+
+    public function getReportingUser()
+    {
+        return $this->data->reporting_user_username;
+    }
+}
+

--- a/app/templates/Event/_common/event_header.html.twig
+++ b/app/templates/Event/_common/event_header.html.twig
@@ -25,6 +25,7 @@
             <li><a href="{{ urlFor('event-talk-comments', {"friendly_name": event.getUrlFriendlyName}) }}">Talk comments</a></li>
             {% if event.getCanEdit %}
             <li><a href="{{ urlFor('event-edit', {"friendly_name": event.getUrlFriendlyName}) }}">Edit</a></li>
+            <li><a href="{{ urlFor('event-reported-comments', {"friendly_name": event.getUrlFriendlyName}) }}">Reported comments</a></li>
             {% endif %}
         </ul>
     </nav>

--- a/app/templates/Event/reported-comments.html.twig
+++ b/app/templates/Event/reported-comments.html.twig
@@ -1,0 +1,28 @@
+{% extends '/layout.html.twig' %}
+
+{% block title %}{{ event.getName }} reported comments - Joind.in{% endblock %}
+{% block extraAside %}
+<section>
+    {% include 'Event/_common/event_details.html.twig' %}
+</section>
+{% endblock %}
+
+{% block body %}
+    {% include 'Event/_common/event_header.html.twig' %}
+
+    <h2>Event comments</h2>
+    {% for report in eventComments %}
+        <p>Reported at {{ report.getReportingDate|date('H:i \\o\\n j M Y', event.getFullTimezone) }} 
+        by {{ report.getReportingUser }}</p>
+        {% include '_common/comment.html.twig' with {'comment': report.getComment, 'event': event} %}
+    {% endfor %}
+
+    <h2>Talk comments</h2>
+    {% for report in talkComments %}
+        <p>Reported at {{ report.getReportingDate|date('H:i \\o\\n j M Y', event.getFullTimezone) }} 
+        by {{ report.getReportingUser }}</p>
+        {% include '_common/comment.html.twig' with {'comment': report.getComment, 'event': event} %}
+    {% endfor %}
+
+
+{% endblock %}


### PR DESCRIPTION
This just adds a "reported comments" link for event and site admins to
the event navigation, and shows the comments (using the existing comment
template) with information about who reported them.