### PR TITLE
Implement open graph meta data on all event pages

### DIFF
--- a/app/src/View/Functions.php
+++ b/app/src/View/Functions.php
@@ -37,8 +37,17 @@ function initialize(Twig_Environment $env, Slim $app)
         return $url;
     }));
 
-    $env->addFunction(new Twig_SimpleFunction('getCurrentUrl', function () {
-        return $_SERVER['REQUEST_URI'];
+    $env->addFunction(new Twig_SimpleFunction('getCurrentUrl', function ($fullyQualified = false) use ($app) {
+        $url =  $_SERVER['REQUEST_URI'];
+
+        if ($fullyQualified) {
+            $scheme = $app->request()->getScheme();
+            $host = $app->request()->headers('host');
+
+            $url = "$scheme://$host$url";
+        }
+
+        return $url;
     }));
 
     $env->addFunction(

--- a/app/templates/Event/_common/layout_event_details.html.twig
+++ b/app/templates/Event/_common/layout_event_details.html.twig
@@ -1,0 +1,15 @@
+{% extends '/layout.html.twig' %}
+
+{% block extra_meta %}
+    {{ parent() }}
+    <meta property="og:type" content="article">
+    <meta property="og:site_name" content="Joind.in">
+    <meta property="og:title" content="{{ event.getName }} on Joind.in">
+    <meta property="og:url" content="{{ getCurrentUrl(true) }}">
+    <meta property="og:image" content="{{ event.getIcon|img_path("event_icons") }}">
+{% set paragraphs = event.getDescription | split("\n") %}
+    <meta property="og:description" content="{{ paragraphs[0] }}">
+    <meta name="twitter:image" content="{{ event.getIcon|img_path("event_icons") }}" data-page-subject="true">
+    <meta name="twitter:card" content="summary" data-page-subject="true">
+    <meta name="twitter:site" content="@joindin" />
+{% endblock %}

--- a/app/templates/Event/comments.html.twig
+++ b/app/templates/Event/comments.html.twig
@@ -1,4 +1,4 @@
-{% extends '/layout.html.twig' %}
+{% extends 'Event/_common/layout_event_details.html.twig' %}
 
 {% block title %}{{ event.getName }} comments - Joind.in{% endblock %}
 {% block extraAside %}

--- a/app/templates/Event/details.html.twig
+++ b/app/templates/Event/details.html.twig
@@ -1,4 +1,4 @@
-{% extends '/layout.html.twig' %}
+{% extends 'Event/_common/layout_event_details.html.twig' %}
 
 {% block title %}{{ event.getName }} - Joind.in{% endblock %}
     
@@ -75,13 +75,6 @@
 {% endblock %}
 
 {% block extraAside %}
-{% endblock %}
-
-{% block extra_meta %}
-    {{ parent() }}
-    <meta property="og:image" content="{{ event.getIcon|img_path("event_icons") }}">
-    <meta name="twitter:image" content="{{ event.getIcon|img_path("event_icons") }}" data-page-subject="true">
-    <meta name="twitter:card" content="photo" data-page-subject="true">
 {% endblock %}
 
 {% block extra_styles %}

--- a/app/templates/Event/schedule-grid.html.twig
+++ b/app/templates/Event/schedule-grid.html.twig
@@ -1,4 +1,4 @@
-{% extends '/layout.html.twig' %}
+{% extends 'Event/_common/layout_event_details.html.twig' %}
 
 {% block extra_javascript %}{% endblock %}
 

--- a/app/templates/Event/schedule-list.html.twig
+++ b/app/templates/Event/schedule-list.html.twig
@@ -1,4 +1,4 @@
-{% extends '/layout.html.twig' %}
+{% extends 'Event/_common/layout_event_details.html.twig' %}
 
 {% block extra_javascript %}{% endblock %}
 

--- a/app/templates/Event/talk-comments.html.twig
+++ b/app/templates/Event/talk-comments.html.twig
@@ -1,4 +1,4 @@
-{% extends '/layout.html.twig' %}
+{% extends 'Event/_common/layout_event_details.html.twig' %}
 
 {% block title %}{{ event.getName }} talk comments - Joind.in{% endblock %}
 {% block extraAside %}


### PR DESCRIPTION
If someone shares an event from joind.in on social media, provide the relevant open graph protocol data along with the additional Twitter meta data. I've done this for all pages as going forwards is likely that one of the schedule pages will be the shared page, not just the detail page. The comments pages are unlikely to be shared, but it seemed sensible to be consistent.