### PR TITLE
Changes max number of displayed CfPs to 4

### DIFF
--- a/app/src/Application/ApplicationController.php
+++ b/app/src/Application/ApplicationController.php
@@ -29,7 +29,7 @@ class ApplicationController extends BaseController
 
         $eventApi = $this->getEventApi();
         $hotEvents = $eventApi->getEvents($perPage, $start, 'hot');
-        $cfpEvents = $eventApi->getEvents(10, 0, 'cfp', true);
+        $cfpEvents = $eventApi->getEvents(4, 0, 'cfp', true);
 
         $this->render(
             'Application/index.html.twig',


### PR DESCRIPTION
This commit changes the number of CfPs displayed on the main page from 10 to 4. That way the site doesn't look that cluttered anymore.