### PR TITLE
Add claim talk button with link to legacy site

### DIFF
--- a/app/templates/Talk/index.html.twig
+++ b/app/templates/Talk/index.html.twig
@@ -93,5 +93,32 @@
 
 {% endblock %}
 
+
+{% block topAside %}
+{% if not user %}
+    <section>
+        <h2>Claim talk</h2>
+        <p>Are you the speaker of this talk?</p>
+        <p><button type="button" class="btn btn-default" data-toggle="modal" data-target="#claimModal">Claim talk</button></p>
+    </section>
+    {# Temporary popup form the claim talk button #}
+    <div class="modal fade" id="claimModal" tabindex="-1" role="dialog">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h2 class="modal-title" id="claimModalLabel">Sorry</h2>
+          </div>
+          <div class="modal-body">
+            {% set legacy_id = talk.getApiUri()|split('/')|last %}
+            <p>This functionality isn't yet available on our new site.</p>
+            <p>If you'd like to help us provide it then <a href="http://github.com/joindin/joindin-vm">GitHub</a> is the place to start. Otherwise to claim this talk, go to the <a href="https://legacy.joind.in/talk/view/{{ legacy_id }}">legacy website</a></p>
+          </div>
+        </div>
+      </div>
+    </div>
+{% endif %}
+{% endblock %}
+
 {% block extraAside %}
 {% endblock %}


### PR DESCRIPTION
As we're getting so many questions on this, add the claim talk button to the talk page (if you're logged in) and open a popup with a link to the legacy site.

Images: 
* Claim talk button: https://i.19ft.com/a7a5bcd9.png
* Popup: https://i.19ft.com/35bc0714.png