### PR TITLE
Fixes number of CfPs on Event-subpage

### DIFF
--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -59,7 +59,7 @@ class EventController extends BaseController
         $start = ($page -1) * $this->itemsPerPage;
 
         $eventApi = $this->getEventApi();
-        $cfpEvents = $eventApi->getEvents(10, 0, 'cfp', true);
+        $cfpEvents = $eventApi->getEvents(4, 0, 'cfp', true);
         $events = $eventApi->getEvents(
             $this->itemsPerPage,
             $start,


### PR DESCRIPTION
Currently on the main entry page only 4 CfPs are shown. Until now the /event-page showed 10 CfPs as that one slipped my eyes when I altered showing only 4 CfPs. 

So this is the fix to that.