### PR TITLE
Better redirect on login failure

### DIFF
--- a/app/src/User/UserController.php
+++ b/app/src/User/UserController.php
@@ -865,7 +865,7 @@ class UserController extends BaseController
             if (empty($redirect)) {
                 $redirect = '/';
             }
-            $this->application->redirect($redirect);
+            $this->application->redirect($redirect . '#login');
         }
         
         session_regenerate_id(true);

--- a/app/templates/_common/login.html.twig
+++ b/app/templates/_common/login.html.twig
@@ -28,5 +28,5 @@
         <a href="{{ urlFor('user-password-reset') }}">Forgotten&nbsp;password</a><br>
         <a href="{{ urlFor('user-username-reminder') }}">Forgotten&nbsp;username</a>
     </div>
-    <input type="hidden" name="redirect" value="{{ redirect ? redirect : getCurrentUrl() ~ '#loginheader' }}">
+    <input type="hidden" name="redirect" value="{{ redirect ? redirect : getCurrentUrl() }}">
 </form>


### PR DESCRIPTION
Rather than always jumping to the login form after authenticating, it is better to only jump to it on login failure.

This PR will remove the `#loginheader` fragment that you see in the URL after logging in.