### PR TITLE
Add admin nav-bar to event page

### DIFF
--- a/app/templates/Event/_common/event_header.html.twig
+++ b/app/templates/Event/_common/event_header.html.twig
@@ -17,33 +17,5 @@
             </h1>
         </div>
     </div>
-    <nav class="page-nav">
-        <ul class="nav nav-pills">
-            {% set event_sub_menu = [
-                {"route":"event-detail", "name":"Details", "active_match": ['event-detail']},
-                {"route":"event-schedule", "name":"Schedule",
-                    "active_match": ['event-default', 'event-schedule-list', 'event-schedule-grid']},
-                {"route":"event-comments", "name":"Event comments", "active_match": ['event-comments']},
-                {"route":"event-talk-comments", "name":"Talk comments", "active_match": ['event-talk-comments']}
-            ] %}
-
-            {% for item in event_sub_menu %}
-            <li class="{% if getCurrentRoute() in item.active_match %}active{% endif %}">
-                <a href="{{ urlFor(item.route, {"friendly_name": event.getUrlFriendlyName}) }}">{{ item.name }}</a>
-            </li>
-            {% endfor %}
-        </ul>
-    </nav>
-    {% if event.getCanEdit %}
-    <nav class="page-nav admin">
-        <ul class="nav nav-pills">
-            <li class="{% if getCurrentRoute() == 'event-edit' %}active{% endif %}">
-                <a href="{{ urlFor('event-edit', {"friendly_name": event.getUrlFriendlyName}) }}">Edit</a>
-            </li>
-            <li class="{% if getCurrentRoute() == 'event-reported-comments' %}active{% endif %}">
-                <a href="{{ urlFor('event-reported-comments', {"friendly_name": event.getUrlFriendlyName}) }}">Reported comments</a>
-            </li>
-        </ul>
-    </nav>
-    {% endif %}
+    {% include 'Event/_common/event_nav.html.twig' %}
 </div>

--- a/app/templates/Event/_common/event_header.html.twig
+++ b/app/templates/Event/_common/event_header.html.twig
@@ -32,15 +32,18 @@
                 <a href="{{ urlFor(item.route, {"friendly_name": event.getUrlFriendlyName}) }}">{{ item.name }}</a>
             </li>
             {% endfor %}
-
-            {% if event.getCanEdit %}
+        </ul>
+    </nav>
+    {% if event.getCanEdit %}
+    <nav class="page-nav admin">
+        <ul class="nav nav-pills">
             <li class="{% if getCurrentRoute() == 'event-edit' %}active{% endif %}">
                 <a href="{{ urlFor('event-edit', {"friendly_name": event.getUrlFriendlyName}) }}">Edit</a>
             </li>
             <li class="{% if getCurrentRoute() == 'event-reported-comments' %}active{% endif %}">
                 <a href="{{ urlFor('event-reported-comments', {"friendly_name": event.getUrlFriendlyName}) }}">Reported comments</a>
             </li>
-            {% endif %}
         </ul>
     </nav>
+    {% endif %}
 </div>

--- a/app/templates/Event/_common/event_nav.html.twig
+++ b/app/templates/Event/_common/event_nav.html.twig
@@ -1,0 +1,32 @@
+{# By default, top_border is on #}
+{% if top_border is not defined %} {% set top_border = true %} {% endif %}
+
+    <nav class="page-nav {% if top_border == false %}no-top-border{% endif %}">
+        <ul class="nav nav-pills">
+            {% set event_sub_menu = [
+                {"route":"event-detail", "name":"Details", "active_match": ['event-detail']},
+                {"route":"event-schedule", "name":"Schedule",
+                    "active_match": ['event-default', 'event-schedule-list', 'event-schedule-grid']},
+                {"route":"event-comments", "name":"Event comments", "active_match": ['event-comments']},
+                {"route":"event-talk-comments", "name":"Talk comments", "active_match": ['event-talk-comments']}
+            ] %}
+
+            {% for item in event_sub_menu %}
+            <li class="{% if getCurrentRoute() in item.active_match %}active{% endif %}">
+                <a href="{{ urlFor(item.route, {"friendly_name": event.getUrlFriendlyName}) }}">{{ item.name }}</a>
+            </li>
+            {% endfor %}
+        </ul>
+    </nav>
+    {% if event.getCanEdit %}
+    <nav class="page-nav admin">
+        <ul class="nav nav-pills">
+            <li class="{% if getCurrentRoute() == 'event-edit' %}active{% endif %}">
+                <a href="{{ urlFor('event-edit', {"friendly_name": event.getUrlFriendlyName}) }}">Edit</a>
+            </li>
+            <li class="{% if getCurrentRoute() == 'event-reported-comments' %}active{% endif %}">
+                <a href="{{ urlFor('event-reported-comments', {"friendly_name": event.getUrlFriendlyName}) }}">Reported comments</a>
+            </li>
+        </ul>
+    </nav>
+    {% endif %}

--- a/app/templates/Event/edit.html.twig
+++ b/app/templates/Event/edit.html.twig
@@ -5,23 +5,34 @@
 {% block title %}Edit {{ event.getName }} - Joind.in{% endblock %}
 
 {% block body %}
-    {% if user %}
-        <style>
-            label.required:after {
-                content: ' *'
-            }
-        </style>
-        <h1 class="title">Edit {{ event.name }}</h1>
-        <p>
-            Edit your event here. The site is aimed at events with sessions, where organisers are looking to
-            use this as a tool to gather feedback.
-        </p>
-        <p>
-            Please supply a description of your event in English, we will consider which events fit our intended
-            criteria (community event, clear description, intent to gather feedback) before approving; you may
-            <a href="{{ urlFor('about') }}">contact us</a> if you have any questions.
-        </p>
-    {% endif %}
+    <h1 class="title">Edit {{ event.name }}</h1>
+    <div class="page-header">
+        <div class="row event">
+            <div class="col-sm-12">
+                {% include 'Event/_common/event_nav.html.twig' with {'top_border': false} %}
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-sm-12">
+            <p>
+                Edit your event here. The site is aimed at events with sessions, where organisers are looking to
+                use this as a tool to gather feedback.
+            </p>
+            <p>
+                Please supply a description of your event in English, we will consider which events fit our intended
+                criteria (community event, clear description, intent to gather feedback) before approving; you may
+                <a href="{{ urlFor('about') }}">contact us</a> if you have any questions.
+            </p>
+        </div>
+    </div>
+    
+    <style>
+        label.required:after {
+            content: ' *'
+        }
+    </style>
     {{ block('form') }}
 {% endblock %}
 

--- a/app/templates/Event/index.html.twig
+++ b/app/templates/Event/index.html.twig
@@ -4,13 +4,17 @@
 
 {% block body %}
     {% if user.admin %}
-    <nav class="page-nav admin">
-        <ul class="nav nav-pills">
-            <li><a href="{{ urlFor('events-pending') }}">Pending events</a></li>
-        </ul>
-    </nav>
+    <div class="page-header">
+        <h1 class="title">Upcoming events</h1>
+        <nav class="page-nav admin no-top-border">
+            <ul class="nav nav-pills">
+                <li><a href="{{ urlFor('events-pending') }}">Pending events</a></li>
+            </ul>
+        </nav>
+    </div>
+    {% else %}
+        <h1 class="title">Upcoming events</h1>
     {% endif %}
-    <h1 class="title">Upcoming events</h1>
     {% if flash.getMessages.message %}
         <div class="alert alert-success">{{ flash.getMessages.message|nl2br }}</div>
     {% endif %}

--- a/web/css/joindin.css
+++ b/web/css/joindin.css
@@ -65,7 +65,6 @@ nav.navbar a.navbar-brand img {
     margin-top: 4px;
     padding-top: 1px;
     padding-bottom: 1px;
-    border-top: none;
     background-color: #FFFEDC;
 }
 .page-nav.admin .nav > li > a:hover, .page-nav.admin .nav > li > a:focus {

--- a/web/css/joindin.css
+++ b/web/css/joindin.css
@@ -51,6 +51,11 @@ nav.navbar a.navbar-brand img {
     margin-bottom: 0px
 }
 
+.page-nav.no-top-border {
+    border-top: none;
+    margin-top: 0;
+}
+
 .page-header {
   margin: 10px 0 20px;
   padding-bottom: 0;

--- a/web/css/joindin.css
+++ b/web/css/joindin.css
@@ -82,6 +82,16 @@ form.navbar-form {
     color: #428bca;
 }
 
+.page-nav.admin .nav-pills > li.active > a, .page-nav.admin .nav-pills > li.active > a:focus {
+    font-weight: bold;
+    background-color: #FFFEDC;
+    color: #428bca;
+}
+.page-nav.admin .nav-pills > li.active > a:hover {
+    background-color: #FFFEDC;
+    color: #428bca;
+}
+
 h1 {
     border-bottom: 1px solid #d7dcdf;
     color: #000;


### PR DESCRIPTION
With both Edit and Reported comments already available and the need to add addtional admin-only menu items, it makes sense to move them to their own nav-bar under the attendee-facing nav-bar.

I've also added the nav-bar to the edit event page as it was missing. This meant separating the nav-bar rendering from the event header template, so I could reuse it.

Finally, for consistency, I've also moved the nav-bar on the Events listing page to below the title too and made it so that there's always a border at the bottom of a nav-bar, but never a situation where we have two borders with no text between them.