### PR TITLE
Fix style of date fields on event form

### DIFF
--- a/app/src/Event/EventFormType.php
+++ b/app/src/Event/EventFormType.php
@@ -239,7 +239,7 @@ class EventFormType extends AbstractType
             // 'widget'      => 'single_text', // force date widgets to show a single HTML5 'date' input
             'constraints' => $constraints,
             'attr'        => [
-                                'class'                     => 'date-picker',
+                                'class'                     => 'date-picker form-control',
                                 'data-provide'              => 'datepicker',
                                 'data-date-format'          => 'd MM yyyy',
                                 'data-date-week-start'      => '1',


### PR DESCRIPTION
The date fields on the event form need the `form-control` class in order to match the style of all the other elements on the form.