### PR TITLE
Add talk to an event

### DIFF
--- a/app/src/Application/BaseController.php
+++ b/app/src/Application/BaseController.php
@@ -48,5 +48,14 @@ abstract class BaseController
         }
     }
 
+    protected function getSessionVariable($name, $default = null)
+    {
+        $value = $default;
+        if (array_key_exists($name, $_SESSION)) {
+            $value = $_SESSION[$name];
+        }
+        return $value;
+    }
+
     abstract protected function defineRoutes(Slim $app);
 }

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -843,6 +843,10 @@ class EventController extends BaseController
         if (!$event) {
             return Slim::getInstance()->notFound();
         }
+        if (!$event->getCanEdit()) {
+            $this->application->flash('error', "You do not have permission to do this.");
+            $this->redirectToDetailPage($event->getUrlFriendlyName());
+        }
 
         $languageApi = $this->getLanguageApi();
         $languages = $languageApi->getLanguagesChoiceList();

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -612,15 +612,15 @@ class EventController extends BaseController
      */
     private function addEventUsingForm(Form $form)
     {
-        $eventapi = $this->geteventapi();
-        $values = $form->getdata();
+        $eventApi = $this->getEventApi();
+        $values = $form->getData();
 
         $result = false;
         try {
-            $result = $eventapi->submit($values);
-        } catch (\exception $e) {
-            $form->adderror(
-                new formerror('an error occurred while submitting your event: ' . $e->getmessage())
+            $result = $eventApi->submit($values);
+        } catch (\Exception $e) {
+            $form->addError(
+                new FormError('an error occurred while submitting your event: ' . $e->getMessage())
             );
         }
 

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -821,7 +821,7 @@ class EventController extends BaseController
 
         /** @var FormFactoryInterface $factory */
         $factory = $this->application->formFactory;
-        $form    = $factory->create(new TalkFormType($event));
+        $form = $factory->create(new TalkFormType($event));
 
         $request = $this->application->request();
         if ($request->isPost()) {

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -858,6 +858,7 @@ class EventController extends BaseController
         foreach ($sessionKeys as $key) {
             $data[$key] = $this->getSessionVariable('add_talk_' . $key);
         }
+        $data['speakers'][] = [];
 
         /** @var FormFactoryInterface $factory */
         $factory = $this->application->formFactory;

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -268,6 +268,8 @@ class EventController extends BaseController
             $scheduleView = 'grid';
         }
 
+        $this->application->flashKeep();
+
         $events_url = $this->application->urlFor("event-schedule-$scheduleView", ['friendly_name' => $friendly_name]);
         $this->application->redirect($events_url);
     }
@@ -829,17 +831,18 @@ class EventController extends BaseController
 
             if ($form->isValid()) {
                 $values = $form->getdata();
-                var_dump($values);exit;
 
                 try {
                     $talkApi = $this->getTalkApi();
-                    $result = $talkApi->addTalk($values);
+                    $result = $talkApi->addTalk($event->getTalksUri(), $values);
 
                     $this->application->flash('message', "Talk added");
-                    $this->redirectToDetailPage($event->getUrlFriendlyName());
+                    $this->application->redirect(
+                        $this->application->urlFor('event-schedule', array('friendly_name' => $event->getUrlFriendlyName()))
+                    );
                 } catch (\Exception $e) {
                     $form->adderror(
-                        new formError('an error occurred while submitting your event: ' . $e->getmessage())
+                        new formError('An error occurred while adding this talk: ' . $e->getmessage())
                     );
                 }
             }

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -697,6 +697,13 @@ class EventController extends BaseController
         return $talkTypeApi;
     }
 
+    protected function getTrackApi()
+    {
+        $trackApi = new TrackApi($this->cfg, $this->accessToken);
+
+        return $trackApi;
+    }
+
     /**
      * Redirects the current request to the event listing page.
      *
@@ -843,9 +850,12 @@ class EventController extends BaseController
         $talkTypeApi = $this->getTalkTypeApi();
         $talkTypes = $talkTypeApi->getTalkTypesChoiceList();
 
+        $trackApi = $this->getTrackApi();
+        $tracks = $trackApi->getTracksChoiceList($event->getTracksUri());
+
         /** @var FormFactoryInterface $factory */
         $factory = $this->application->formFactory;
-        $form = $factory->create(new TalkFormType($event, $languages, $talkTypes));
+        $form = $factory->create(new TalkFormType($event, $languages, $talkTypes, $tracks));
 
         $request = $this->application->request();
         if ($request->isPost()) {

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -11,10 +11,12 @@ use Symfony\Component\Validator\Validator;
 use Talk\TalkDb;
 use Talk\TalkApi;
 use Talk\TalkFormType;
+use Talk\TalkTypeApi;
 use User\UserDb;
 use User\UserApi;
 use Exception;
 use Slim\Slim;
+use Language\LanguageApi;
 
 class EventController extends BaseController
 {
@@ -681,6 +683,20 @@ class EventController extends BaseController
         return $eventApi;
     }
 
+    protected function getLanguageApi()
+    {
+        $languageApi = new LanguageApi($this->cfg, $this->accessToken);
+
+        return $languageApi;
+    }
+
+    protected function getTalkTypeApi()
+    {
+        $talkTypeApi = new TalkTypeApi($this->cfg, $this->accessToken);
+
+        return $talkTypeApi;
+    }
+
     /**
      * Redirects the current request to the event listing page.
      *
@@ -821,9 +837,15 @@ class EventController extends BaseController
             return Slim::getInstance()->notFound();
         }
 
+        $languageApi = $this->getLanguageApi();
+        $languages = $languageApi->getLanguagesChoiceList();
+
+        $talkTypeApi = $this->getTalkTypeApi();
+        $talkTypes = $talkTypeApi->getTalkTypesChoiceList();
+
         /** @var FormFactoryInterface $factory */
         $factory = $this->application->formFactory;
-        $form = $factory->create(new TalkFormType($event));
+        $form = $factory->create(new TalkFormType($event, $languages, $talkTypes));
 
         $request = $this->application->request();
         if ($request->isPost()) {

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -853,9 +853,15 @@ class EventController extends BaseController
         $trackApi = $this->getTrackApi();
         $tracks = $trackApi->getTracksChoiceList($event->getTracksUri());
 
+        // default values
+        $sessionKeys = ['duration', 'language', 'type', 'track'];
+        foreach ($sessionKeys as $key) {
+            $data[$key] = $this->getSessionVariable('add_talk_' . $key);
+        }
+
         /** @var FormFactoryInterface $factory */
         $factory = $this->application->formFactory;
-        $form = $factory->create(new TalkFormType($event, $languages, $talkTypes, $tracks));
+        $form = $factory->create(new TalkFormType($event, $languages, $talkTypes, $tracks), $data);
 
         $request = $this->application->request();
         if ($request->isPost()) {
@@ -863,6 +869,11 @@ class EventController extends BaseController
 
             if ($form->isValid()) {
                 $values = $form->getdata();
+
+                // store some values to session for next form
+                foreach ($sessionKeys as $key) {
+                    $_SESSION['add_talk_' . $key] = $values[$key];
+                }
 
                 try {
                     $talkApi = $this->getTalkApi();

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -882,7 +882,11 @@ class EventController extends BaseController
 
                 try {
                     $talkApi = $this->getTalkApi();
-                    $result = $talkApi->addTalk($event->getTalksUri(), $values);
+                    $talk = $talkApi->addTalk($event->getTalksUri(), $values);
+
+                    if (!empty($values['track']) && isset($tracks[$values['track']])) {
+                        $talkApi->addTalkToTrack($talk->getTracksUri(), $values['track']);
+                    }
 
                     $this->application->flash('message', "Talk added");
                     $this->application->redirect(

--- a/app/src/Event/EventEntity.php
+++ b/app/src/Event/EventEntity.php
@@ -546,6 +546,11 @@ class EventEntity
         return $this->data->images_uri;
     }
 
+    public function getTracksUri()
+    {
+        return $this->data->tracks_uri;
+    }
+
     /**
      * Used by the edit form
      */

--- a/app/src/Event/TrackApi.php
+++ b/app/src/Event/TrackApi.php
@@ -1,0 +1,46 @@
+<?php
+namespace Event;
+
+use Application\BaseApi;
+
+class TrackApi extends BaseApi
+{
+    public function __construct($config, $accessToken)
+    {
+        parent::__construct($config, $accessToken);
+    }
+
+    /**
+     * Retrieve list of tracks from the API
+     *
+     * @return array
+     */
+    public function getTracks($url)
+    {
+        $queryParams['resultsperpage'] = 0;
+
+        $result = $this->apiGet($url, $queryParams);
+        if (!$result) {
+            throw new \RuntimeException('Unable to retrieve list of tracks');
+        }
+
+        return json_decode($result, true);
+    }
+
+    /**
+     * Return the list of tracks in a format suitable for a choice list
+     *
+     * @return array
+     */
+    public function getTracksChoiceList($url)
+    {
+        $tracks = [];
+
+        $list = $this->getTracks($url);
+        foreach ($list['tracks'] as $track) {
+            $tracks[$track['track_name']] = $track['track_name'];
+        }
+
+        return $tracks;
+    }
+}

--- a/app/src/Event/TrackApi.php
+++ b/app/src/Event/TrackApi.php
@@ -38,7 +38,7 @@ class TrackApi extends BaseApi
 
         $list = $this->getTracks($url);
         foreach ($list['tracks'] as $track) {
-            $tracks[$track['track_name']] = $track['track_name'];
+            $tracks[$track['uri']] = $track['track_name'];
         }
 
         return $tracks;

--- a/app/src/Language/LanguageApi.php
+++ b/app/src/Language/LanguageApi.php
@@ -1,0 +1,47 @@
+<?php
+namespace Language;
+
+use Application\BaseApi;
+
+class LanguageApi extends BaseApi
+{
+    public function __construct($config, $accessToken)
+    {
+        parent::__construct($config, $accessToken);
+    }
+
+    /**
+     * Retrieve list of languages from the API
+     *
+     * @return array
+     */
+    public function getLanguages()
+    {
+        $url = $this->baseApiUrl . '/v2.1/languages';
+        $queryParams['resultsperpage'] = 0;
+
+        $result = $this->apiGet($url, $queryParams);
+        if (!$result) {
+            throw new \RuntimeException('Unable to retrieve list of languages');
+        }
+
+        return json_decode($result, true);
+    }
+
+    /**
+     * Return the list of languages in a format suitable for a choice list
+     *
+     * @return array
+     */
+    public function getLanguagesChoiceList()
+    {
+        $languages = [];
+
+        $list = $this->getLanguages();
+        foreach ($list['languages'] as $language) {
+            $languages[$language['name']] = $language['name'];
+        }
+
+        return $languages;
+    }
+}

--- a/app/src/Talk/SpeakerFormType.php
+++ b/app/src/Talk/SpeakerFormType.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Talk;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+use Event\EventEntity;
+
+/**
+ * Form used to render and validate the speakers collection on a Talk form
+ */
+class SpeakerFormType extends AbstractType
+{
+    /**
+     * Returns the name of this form type.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'speaker';
+    }
+
+    /**
+     * Adds fields with their types and validation constraints to this definition.
+     *
+     * @param FormBuilderInterface $builder
+     * @param array                $options
+     *
+     * @return void
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('name', 'text', [
+                'label' => false,
+                'required' => false,
+            ])
+        ;
+    }
+}

--- a/app/src/Talk/TalkApi.php
+++ b/app/src/Talk/TalkApi.php
@@ -240,4 +240,36 @@ class TalkApi extends BaseApi
 
         return $agenda;
     }
+
+    /**
+     * Add a talk to an event
+     *
+     * @param string $talksUri
+     * @param array $data
+     */
+    public function addTalk($talksUri, $data)
+    {
+        array_walk($data, function (&$value) {
+            if ($value instanceof \DateTimeInterface) {
+                $value = $value->format('Y-m-d H:i');
+            }
+        });
+        list ($status, $result, $headers) = $this->apiPost($talksUri, $data);
+        // if successful, return talk entity represented by the URL in the Location header
+        if ($status == 201) {
+            $response = $this->getCollection($headers['location']);
+            return current($response['talks']);
+        }
+        if ($status == 202) {
+            return null;
+        }
+        if ($status == 400) {
+            $decoded = json_decode($result);
+            if (is_array($decoded)) {
+                $result = current($decoded);
+            }
+        }
+
+        throw new \Exception($result);
+    }
 }

--- a/app/src/Talk/TalkApi.php
+++ b/app/src/Talk/TalkApi.php
@@ -285,4 +285,29 @@ class TalkApi extends BaseApi
 
         throw new \Exception($result);
     }
+
+    /**
+     * Add a talk to a track
+     *
+     * @param  $talkTracksUri
+     * @param  $trackUri
+     *
+     * @return  bool
+     */
+    public function addTalkToTrack($talkTracksUri, $trackUri)
+    {
+        $params = [
+            'track_uri' => $trackUri,
+        ];
+
+        list($status, $result, $headers) = $this->apiPost($talkTracksUri, $params);
+        if ($status == 201) {
+            return true;
+        }
+
+        $result = json_decode($result);
+        $message = $result[0];
+        
+        throw new \Exception("Failed: " . $message);
+    }
 }

--- a/app/src/Talk/TalkApi.php
+++ b/app/src/Talk/TalkApi.php
@@ -254,6 +254,19 @@ class TalkApi extends BaseApi
                 $value = $value->format('Y-m-d H:i');
             }
         });
+
+        // ensure that speakers is a list of names with no empty ones
+        if (isset($data['speakers'])) {
+            array_walk($data['speakers'], function (&$value) {
+                if (is_array($value)) {
+                    $value = current($value);
+                }
+                $value = trim($value);
+            });
+            $data['speakers'] = array_filter($data['speakers']);
+        }
+
+
         list ($status, $result, $headers) = $this->apiPost($talksUri, $data);
         // if successful, return talk entity represented by the URL in the Location header
         if ($status == 201) {

--- a/app/src/Talk/TalkEntity.php
+++ b/app/src/Talk/TalkEntity.php
@@ -150,4 +150,9 @@ class TalkEntity
     {
         return $this->data->starred_uri;
     }
+
+    public function getTracksUri()
+    {
+        return $this->data->tracks_uri;
+    }
 }

--- a/app/src/Talk/TalkFormType.php
+++ b/app/src/Talk/TalkFormType.php
@@ -27,12 +27,25 @@ class TalkFormType extends AbstractType
      */
     protected $endDate;
 
-    public function __construct(EventEntity $event)
+    /**
+     * @var [string]
+     */
+    protected $languages;
+
+    /**
+     * @var [string]
+     */
+    protected $talkTypes;
+
+    public function __construct(EventEntity $event, array $languages, array $talkTypes)
     {
         $this->timezone = $event->getFullTimezone();
         $tz = new \DateTimeZone($this->timezone);
         $this->startDate = new \DateTimeImmutable($event->getStartDate(), $tz);
         $this->endDate = new \DateTimeImmutable($event->getEndDate(), $tz);
+
+        $this->languages = $languages;
+        $this->talkTypes = $talkTypes;
     }
 
 
@@ -130,6 +143,20 @@ class TalkFormType extends AbstractType
                             'message' => 'Value must be a positive number.'
                         ]),
                     ],
+                ]
+            )
+            ->add(
+                'language',
+                'choice',
+                [
+                    'choices' => ['' => '']  + $this->languages
+                ]
+            )
+            ->add(
+                'type',
+                'choice',
+                [
+                    'choices' => ['' => '']  + $this->talkTypes
                 ]
             )
         ;

--- a/app/src/Talk/TalkFormType.php
+++ b/app/src/Talk/TalkFormType.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Talk;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+use Form\DataTransformer\DateTransformer;
+use Form\DataTransformer\EventTagsTransformer;
+
+/**
+ * Form used to render and validate the submission or editing of a talk.
+ *
+ * Usage (extraneous use of variables is made to illustrate which parts are used):
+ *
+ * ```
+ * $formType = new TalkFormType();
+ * $factory  = $this->application->formFactory;
+ * $form     = $factory->create($formType);
+ * $formName = $form->getName();
+ *
+ * if ($this->application->request()->isPost()) {
+ *     $data = $request->post($formName);
+ *
+ *     $form->submit($data);
+ *
+ *     if ($form->isValid()) {
+ *         // ... perform success actions
+ *     }
+ * }
+ * ```
+ */
+class TalkFormType extends AbstractType
+{
+    /**
+     * Returns the name of this form type.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'talk';
+    }
+
+    /**
+     * Adds fields with their types and validation constraints to this definition.
+     *
+     * This method is automatically called by the Form Factory builder and does not need
+     * to be called manually, see the class description for usage information.
+     *
+     * @param FormBuilderInterface $builder
+     * @param array                $options
+     *
+     * @return void
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $timezone = null;
+        if (isset($options['data'])) {
+            $timezone = $options['data']->getFullTimezone();
+        }
+
+        $dateTransformer = new DateTransformer($timezone);
+        $builder
+            ->add('addr', 'hidden', ['mapped' => false])
+            ->add(
+                'talk_title',
+                'text',
+                [
+                    'constraints' => [new Assert\NotBlank()],
+                ]
+            )
+            ->add(
+                'talk_description',
+                'textarea',
+                [
+                    'constraints' => [new Assert\NotBlank()],
+                    'attr'=> ['rows' => '10']
+                ]
+            )
+            ->add(
+                'slides_link',
+                'url',
+                [
+                    'constraints' => [new Assert\Url()],
+                    'required' => false,
+                ]
+            )
+        ;
+    }
+}

--- a/app/src/Talk/TalkFormType.php
+++ b/app/src/Talk/TalkFormType.php
@@ -37,7 +37,12 @@ class TalkFormType extends AbstractType
      */
     protected $talkTypes;
 
-    public function __construct(EventEntity $event, array $languages, array $talkTypes)
+    /**
+     * @var [string]
+     */
+    protected $track;
+
+    public function __construct(EventEntity $event, array $languages, array $talkTypes, array $tracks)
     {
         $this->timezone = $event->getFullTimezone();
         $tz = new \DateTimeZone($this->timezone);
@@ -46,6 +51,7 @@ class TalkFormType extends AbstractType
 
         $this->languages = $languages;
         $this->talkTypes = $talkTypes;
+        $this->tracks = $tracks;
     }
 
 
@@ -157,6 +163,14 @@ class TalkFormType extends AbstractType
                 'choice',
                 [
                     'choices' => ['' => '']  + $this->talkTypes
+                ]
+            )
+            ->add(
+                'track',
+                'choice',
+                [
+                    'required' => (bool) !empty($this->tracks),
+                    'choices' => ['' => '']  + $this->tracks
                 ]
             )
         ;

--- a/app/src/Talk/TalkFormType.php
+++ b/app/src/Talk/TalkFormType.php
@@ -76,7 +76,6 @@ class TalkFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('addr', 'hidden', ['mapped' => false])
             ->add(
                 'talk_title',
                 'text',

--- a/app/src/Talk/TalkFormType.php
+++ b/app/src/Talk/TalkFormType.php
@@ -172,6 +172,15 @@ class TalkFormType extends AbstractType
                     'choices' => ['' => '']  + $this->tracks
                 ]
             )
+            ->add(
+                'speakers',
+                'collection',
+                [
+                    'label' => 'Speakers!',
+                    'type' => new SpeakerFormType(),
+                    'allow_add' => true,
+                ]
+            )
         ;
     }
 }

--- a/app/src/Talk/TalkTypeApi.php
+++ b/app/src/Talk/TalkTypeApi.php
@@ -1,0 +1,47 @@
+<?php
+namespace Talk;
+
+use Application\BaseApi;
+
+class TalkTypeApi extends BaseApi
+{
+    public function __construct($config, $accessToken)
+    {
+        parent::__construct($config, $accessToken);
+    }
+
+    /**
+     * Retrieve list of talk types from the API
+     *
+     * @return array
+     */
+    public function getTalkTypes()
+    {
+        $url = $this->baseApiUrl . '/v2.1/talk_types';
+        $queryParams['resultsperpage'] = 0;
+
+        $result = $this->apiGet($url, $queryParams);
+        if (!$result) {
+            throw new \RuntimeException('Unable to retrieve list of talk types');
+        }
+
+        return json_decode($result, true);
+    }
+
+    /**
+     * Return the list of talk types in a format suitable for a choice list
+     *
+     * @return array
+     */
+    public function getTalkTypesChoiceList()
+    {
+        $types = [];
+
+        $list = $this->getTalkTypes();
+        foreach ($list['talk_types'] as $type) {
+            $types[$type['title']] = $type['title'];
+        }
+
+        return $types;
+    }
+}

--- a/app/templates/Event/_common/event_header.html.twig
+++ b/app/templates/Event/_common/event_header.html.twig
@@ -17,33 +17,5 @@
             </h1>
         </div>
     </div>
-    <nav class="page-nav">
-        <ul class="nav nav-pills">
-            {% set event_sub_menu = [
-                {"route":"event-detail", "name":"Details", "active_match": ['event-detail']},
-                {"route":"event-schedule", "name":"Schedule",
-                    "active_match": ['event-default', 'event-schedule-list', 'event-schedule-grid']},
-                {"route":"event-comments", "name":"Event comments", "active_match": ['event-comments']},
-                {"route":"event-talk-comments", "name":"Talk comments", "active_match": ['event-talk-comments']}
-            ] %}
-
-            {% for item in event_sub_menu %}
-            <li class="{% if getCurrentRoute() in item.active_match %}active{% endif %}">
-                <a href="{{ urlFor(item.route, {"friendly_name": event.getUrlFriendlyName}) }}">{{ item.name }}</a>
-            </li>
-            {% endfor %}
-        </ul>
-    </nav>
-    {% if event.getCanEdit %}
-    <nav class="page-nav admin">
-        <ul class="nav nav-pills">
-            <li class="{% if getCurrentRoute() == 'event-edit' %}active{% endif %}">
-                <a href="{{ urlFor('event-edit', {"friendly_name": event.getUrlFriendlyName}) }}">Edit</a>
-            </li>
-            <li class="{% if getCurrentRoute() == 'event-reported-comments' %}active{% endif %}">
-                <a href="{{ urlFor('event-reported-comments', {"friendly_name": event.getUrlFriendlyName}) }}">Reported comments</a>
-            </li>
-        </ul>
-    </nav>
-    {% endif %}
+    {% include 'Event/_common/event_nav.html.twig' %}
 </div>

--- a/app/templates/Event/_common/event_header.html.twig
+++ b/app/templates/Event/_common/event_header.html.twig
@@ -18,4 +18,11 @@
         </div>
     </div>
     {% include 'Event/_common/event_nav.html.twig' %}
+
+    {% if flash.getMessages.message %}
+        <div class="top-spacer alert alert-success">{{flash.getMessages.message}}</div>
+    {% endif %}
+    {% if flash.getMessages.error %}
+        <div class="top-spacer alert alert-danger">{{flash.getMessages.error}}</div>
+    {% endif %}
 </div>

--- a/app/templates/Event/_common/event_header.html.twig
+++ b/app/templates/Event/_common/event_header.html.twig
@@ -32,15 +32,18 @@
                 <a href="{{ urlFor(item.route, {"friendly_name": event.getUrlFriendlyName}) }}">{{ item.name }}</a>
             </li>
             {% endfor %}
-
-            {% if event.getCanEdit %}
+        </ul>
+    </nav>
+    {% if event.getCanEdit %}
+    <nav class="page-nav admin">
+        <ul class="nav nav-pills">
             <li class="{% if getCurrentRoute() == 'event-edit' %}active{% endif %}">
                 <a href="{{ urlFor('event-edit', {"friendly_name": event.getUrlFriendlyName}) }}">Edit</a>
             </li>
             <li class="{% if getCurrentRoute() == 'event-reported-comments' %}active{% endif %}">
                 <a href="{{ urlFor('event-reported-comments', {"friendly_name": event.getUrlFriendlyName}) }}">Reported comments</a>
             </li>
-            {% endif %}
         </ul>
     </nav>
+    {% endif %}
 </div>

--- a/app/templates/Event/_common/event_nav.html.twig
+++ b/app/templates/Event/_common/event_nav.html.twig
@@ -1,0 +1,32 @@
+{# By default, top_border is on #}
+{% if top_border is not defined %} {% set top_border = true %} {% endif %}
+
+    <nav class="page-nav {% if top_border == false %}no-top-border{% endif %}">
+        <ul class="nav nav-pills">
+            {% set event_sub_menu = [
+                {"route":"event-detail", "name":"Details", "active_match": ['event-detail']},
+                {"route":"event-schedule", "name":"Schedule",
+                    "active_match": ['event-default', 'event-schedule-list', 'event-schedule-grid']},
+                {"route":"event-comments", "name":"Event comments", "active_match": ['event-comments']},
+                {"route":"event-talk-comments", "name":"Talk comments", "active_match": ['event-talk-comments']}
+            ] %}
+
+            {% for item in event_sub_menu %}
+            <li class="{% if getCurrentRoute() in item.active_match %}active{% endif %}">
+                <a href="{{ urlFor(item.route, {"friendly_name": event.getUrlFriendlyName}) }}">{{ item.name }}</a>
+            </li>
+            {% endfor %}
+        </ul>
+    </nav>
+    {% if event.getCanEdit %}
+    <nav class="page-nav admin">
+        <ul class="nav nav-pills">
+            <li class="{% if getCurrentRoute() == 'event-edit' %}active{% endif %}">
+                <a href="{{ urlFor('event-edit', {"friendly_name": event.getUrlFriendlyName}) }}">Edit</a>
+            </li>
+            <li class="{% if getCurrentRoute() == 'event-reported-comments' %}active{% endif %}">
+                <a href="{{ urlFor('event-reported-comments', {"friendly_name": event.getUrlFriendlyName}) }}">Reported comments</a>
+            </li>
+        </ul>
+    </nav>
+    {% endif %}

--- a/app/templates/Event/_common/event_nav.html.twig
+++ b/app/templates/Event/_common/event_nav.html.twig
@@ -24,6 +24,9 @@
             <li class="{% if getCurrentRoute() == 'event-edit' %}active{% endif %}">
                 <a href="{{ urlFor('event-edit', {"friendly_name": event.getUrlFriendlyName}) }}">Edit</a>
             </li>
+            <li class="{% if getCurrentRoute() == 'event-add-talk' %}active{% endif %}">
+                <a href="{{ urlFor('event-add-talk', {"friendly_name": event.getUrlFriendlyName}) }}">Add talk</a>
+            </li>
             <li class="{% if getCurrentRoute() == 'event-reported-comments' %}active{% endif %}">
                 <a href="{{ urlFor('event-reported-comments', {"friendly_name": event.getUrlFriendlyName}) }}">Reported comments</a>
             </li>

--- a/app/templates/Event/add-talk.html.twig
+++ b/app/templates/Event/add-talk.html.twig
@@ -15,3 +15,7 @@
 {% block extra_styles %}
     {{ block('form_extra_styles') }}
 {% endblock %}
+
+{% block extra_javascript %}
+    {{ block('form_extra_javascript') }}
+{% endblock %}

--- a/app/templates/Event/add-talk.html.twig
+++ b/app/templates/Event/add-talk.html.twig
@@ -1,0 +1,13 @@
+{% extends '/layout.html.twig' %}
+
+{% use '/Talk/_common/form.html.twig' %}
+
+{% block body %}
+    {% include 'Event/_common/event_header.html.twig' %}
+    <h2>Add a talk to this event</h2>
+    {{ block('form') }}
+{% endblock %}
+
+{% block extra_styles %}
+    {{ block('form_extra_styles') }}
+{% endblock %}

--- a/app/templates/Event/add-talk.html.twig
+++ b/app/templates/Event/add-talk.html.twig
@@ -1,5 +1,9 @@
 {% extends '/layout.html.twig' %}
 
+{% block title %}Add talk to {{ event.getName }} - Joind.in{% endblock %}
+
+{% form_theme form _self %}
+    
 {% use '/Talk/_common/form.html.twig' %}
 
 {% block body %}

--- a/app/templates/Event/edit.html.twig
+++ b/app/templates/Event/edit.html.twig
@@ -5,23 +5,34 @@
 {% block title %}Edit {{ event.getName }} - Joind.in{% endblock %}
 
 {% block body %}
-    {% if user %}
-        <style>
-            label.required:after {
-                content: ' *'
-            }
-        </style>
-        <h1 class="title">Edit {{ event.name }}</h1>
-        <p>
-            Edit your event here. The site is aimed at events with sessions, where organisers are looking to
-            use this as a tool to gather feedback.
-        </p>
-        <p>
-            Please supply a description of your event in English, we will consider which events fit our intended
-            criteria (community event, clear description, intent to gather feedback) before approving; you may
-            <a href="{{ urlFor('about') }}">contact us</a> if you have any questions.
-        </p>
-    {% endif %}
+    <h1 class="title">Edit {{ event.name }}</h1>
+    <div class="page-header">
+        <div class="row event">
+            <div class="col-sm-12">
+                {% include 'Event/_common/event_nav.html.twig' with {'top_border': false} %}
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-sm-12">
+            <p>
+                Edit your event here. The site is aimed at events with sessions, where organisers are looking to
+                use this as a tool to gather feedback.
+            </p>
+            <p>
+                Please supply a description of your event in English, we will consider which events fit our intended
+                criteria (community event, clear description, intent to gather feedback) before approving; you may
+                <a href="{{ urlFor('about') }}">contact us</a> if you have any questions.
+            </p>
+        </div>
+    </div>
+    
+    <style>
+        label.required:after {
+            content: ' *'
+        }
+    </style>
     {{ block('form') }}
 {% endblock %}
 

--- a/app/templates/Event/index.html.twig
+++ b/app/templates/Event/index.html.twig
@@ -4,13 +4,17 @@
 
 {% block body %}
     {% if user.admin %}
-    <nav class="page-nav admin">
-        <ul class="nav nav-pills">
-            <li><a href="{{ urlFor('events-pending') }}">Pending events</a></li>
-        </ul>
-    </nav>
+    <div class="page-header">
+        <h1 class="title">Upcoming events</h1>
+        <nav class="page-nav admin no-top-border">
+            <ul class="nav nav-pills">
+                <li><a href="{{ urlFor('events-pending') }}">Pending events</a></li>
+            </ul>
+        </nav>
+    </div>
+    {% else %}
+        <h1 class="title">Events</h1>
     {% endif %}
-    <h1 class="title">Events</h1>
     {% if flash.getMessages.message %}
         <div class="alert alert-success">{{ flash.getMessages.message|nl2br }}</div>
     {% endif %}

--- a/app/templates/Talk/_common/form.html.twig
+++ b/app/templates/Talk/_common/form.html.twig
@@ -32,6 +32,14 @@
         </fieldset>
     </div>
     <div class="row">
+        <fieldset class="col-sm-3">
+            {{ form_row(form.language) }}
+        </fieldset>
+        <fieldset class="col-sm-3">
+            {{ form_row(form.type) }}
+        </fieldset>
+    </div>
+    <div class="row">
         <fieldset class="col-sm-12">
             {{ form_row(form.slides_link) }}
         </fieldset>

--- a/app/templates/Talk/_common/form.html.twig
+++ b/app/templates/Talk/_common/form.html.twig
@@ -13,7 +13,6 @@
     </div>
 {%- endblock _talk_start_date_widget -%}
 
-
 {% block form %}
 {{ form_start(form, {'attr' : {'id' : 'event'} }) }}
 {{ form_errors(form) }}
@@ -48,6 +47,17 @@
         </fieldset>
     </div>
     <div class="row">
+        <fieldset class="col-sm-6">
+            <label>Speakers</label>
+            <ul class="speakers" data-prototype="{{ form_widget(form.speakers.vars.prototype)|e }}">
+                {% for speaker in form.speakers %}
+                    <li>{{ form_row(speaker.name) }}</li>
+                {% endfor %}
+            </ul>
+        </fieldset>
+    </div>
+
+    <div class="row">
         <div class="col-sm-12">
             <input type="submit" class="btn btn-primary pull-right" value="Submit" />
             {% if event.urlFriendlyName is defined %}
@@ -67,4 +77,50 @@
 {% endblock %}
 
 {% block form_extra_javascript %}
+<script type="text/javascript">
+var collectionHolder;
+
+// setup an "add a speaker" link
+var addSpeakerLink = $('<a href="#" class="add_speaker_link btn btn-sm btn-default">Add a speaker</a>');
+var newLinkLi = $('<li></li>').append(addSpeakerLink);
+
+jQuery(document).ready(function() {
+    // Get the ul that holds the collection of tags
+    collectionHolder = $('ul.speakers');
+
+    // add the "add a tag" anchor and li to the tags ul
+    collectionHolder.append(newLinkLi);
+
+    // count the current form inputs we have (e.g. 2), use that as the new
+    // index when inserting a new item (e.g. 2)
+    collectionHolder.data('index', collectionHolder.find(':input').length);
+
+    addSpeakerLink.on('click', function(e) {
+        // prevent the link from creating a "#" on the URL
+        e.preventDefault();
+
+        // add a new tag form (see next code block)
+        addSpeakerForm(collectionHolder, newLinkLi);
+    });
+});
+
+function addSpeakerForm($collectionHolder, $newLinkLi) {
+    // Get the data-prototype explained earlier
+    var prototype = $collectionHolder.data('prototype');
+
+    // get the new index
+    var index = $collectionHolder.data('index');
+
+    // Replace '__name__' in the prototype's HTML to
+    // instead be a number based on how many items we have
+    var newForm = prototype.replace(/__name__/g, index);
+
+    // increase the index with one for the next item
+    $collectionHolder.data('index', index + 1);
+
+    // Display the form in the page in an li, before the "Add a speaker" link li
+    var $newFormLi = $('<li></li>').append(newForm);
+    $newLinkLi.before($newFormLi);
+}
+</script>
 {% endblock %}

--- a/app/templates/Talk/_common/form.html.twig
+++ b/app/templates/Talk/_common/form.html.twig
@@ -1,0 +1,31 @@
+{% block form %}
+{{ form_start(form, {'attr' : {'id' : 'event'} }) }}
+{{ form_errors(form) }}
+    <div class="row">
+        <fieldset class="col-sm-12">
+            {{ form_row(form.talk_title) }}
+            {{ form_row(form.talk_description) }}
+            {{ form_row(form.slides_link) }}
+        </fieldset>
+    </div>
+    <div class="row">
+        <div class="col-sm-12">
+            <input type="submit" class="btn btn-primary pull-right" value="Submit" />
+            {% if event.urlFriendlyName is defined %}
+            <a href="{{ urlFor('event-detail', {friendly_name:event.urlFriendlyName}) }}" class="form-cancel pull-right">Cancel</a>
+            {% endif %}
+        </div>
+    </div>
+    {{ form_end(form) }}
+{% endblock %}
+
+{% block form_extra_styles %}
+    <style>
+        label.required:after {
+            content: ' *'
+        }
+    </style>
+{% endblock %}
+
+{% block form_extra_javascript %}
+{% endblock %}

--- a/app/templates/Talk/_common/form.html.twig
+++ b/app/templates/Talk/_common/form.html.twig
@@ -1,3 +1,19 @@
+
+{# Custom widget for talk start date & time #}
+{%- block _talk_start_date_widget -%}
+    <div class="row">
+        <fieldset class="col-sm-8">
+            {{- form_widget(form.date, { 'attr': attr.date_widget }) -}}
+            {{- form_errors(form.date) -}}
+        </fieldset>
+        <fieldset class="col-sm-4">
+            {{- form_widget(form.time, { 'attr': attr.time_widget }) -}}
+            {{- form_errors(form.time) -}}
+        </fieldset>
+    </div>
+{%- endblock _talk_start_date_widget -%}
+
+
 {% block form %}
 {{ form_start(form, {'attr' : {'id' : 'event'} }) }}
 {{ form_errors(form) }}
@@ -5,6 +21,18 @@
         <fieldset class="col-sm-12">
             {{ form_row(form.talk_title) }}
             {{ form_row(form.talk_description) }}
+        </fieldset>
+    </div>
+    <div class="row">
+        <fieldset class="col-sm-5">
+            {{ form_row(form.start_date) }}
+        </fieldset>
+        <fieldset class="col-sm-2">
+            {{ form_row(form.duration) }}
+        </fieldset>
+    </div>
+    <div class="row">
+        <fieldset class="col-sm-12">
             {{ form_row(form.slides_link) }}
         </fieldset>
     </div>

--- a/app/templates/Talk/_common/form.html.twig
+++ b/app/templates/Talk/_common/form.html.twig
@@ -38,6 +38,9 @@
         <fieldset class="col-sm-3">
             {{ form_row(form.type) }}
         </fieldset>
+        <fieldset class="col-sm-4">
+            {{ form_row(form.track) }}
+        </fieldset>
     </div>
     <div class="row">
         <fieldset class="col-sm-12">

--- a/app/templates/layout.html.twig
+++ b/app/templates/layout.html.twig
@@ -13,6 +13,7 @@
     <link href="/css/bootstrap-theme.min.css" rel="stylesheet">
     <link href="/css/font-awesome-custom.css" rel="stylesheet">
     <link href="/css/datepicker3.css" rel="stylesheet">
+    <link href="/css/bootstrap-timepicker.css" rel="stylesheet">
     <link href="/css/joindin.css" rel="stylesheet">
     {% block extra_styles %}{% endblock %}
 </head>
@@ -128,6 +129,7 @@
     <script type="text/javascript" src="/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="/js/jquery.rateit.min.js"></script>
     <script type="text/javascript" src="/js/bootstrap-datepicker.js"></script>
+    <script type="text/javascript" src="/js/bootstrap-timepicker.js"></script>
     <script type="text/javascript" src="/js/joindin.js"></script>
 
 {% block extra_javascript %}{% endblock %}

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
         "psr-0":{
             "Application": ["app/src/", "tests/"],
             "Form":        ["app/src/", "tests/"],
+            "Language":    ["app/src/", "tests/"],
             "Middleware":  ["app/src/", "tests/"],
             "Event":       ["app/src/", "tests/"],
             "Search":      ["app/src/", "tests/"],

--- a/vendor/composer/autoload_namespaces.php
+++ b/vendor/composer/autoload_namespaces.php
@@ -24,6 +24,7 @@ return array(
     'Search' => array($baseDir . '/app/src', $baseDir . '/tests'),
     'Predis' => array($vendorDir . '/predis/predis/lib'),
     'Middleware' => array($baseDir . '/app/src', $baseDir . '/tests'),
+    'Language' => array($baseDir . '/app/src', $baseDir . '/tests'),
     'Form' => array($baseDir . '/app/src', $baseDir . '/tests'),
     'Event' => array($baseDir . '/app/src', $baseDir . '/tests'),
     'Application' => array($baseDir . '/app/src', $baseDir . '/tests'),

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -150,6 +150,14 @@ class ComposerStaticInitea939503be411f5478ca4976fabdaa0c
                 1 => __DIR__ . '/../..' . '/tests',
             ),
         ),
+        'L' => 
+        array (
+            'Language' => 
+            array (
+                0 => __DIR__ . '/../..' . '/app/src',
+                1 => __DIR__ . '/../..' . '/tests',
+            ),
+        ),
         'F' => 
         array (
             'Form' => 

--- a/web/css/bootstrap-timepicker.css
+++ b/web/css/bootstrap-timepicker.css
@@ -1,0 +1,146 @@
+/*!
+ * Timepicker Component for Twitter Bootstrap
+ *
+ * Copyright 2013 Joris de Wit
+ *
+ * Contributors https://github.com/jdewit/bootstrap-timepicker/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+.bootstrap-timepicker {
+  position: relative;
+}
+.bootstrap-timepicker.pull-right .bootstrap-timepicker-widget.dropdown-menu {
+  left: auto;
+  right: 0;
+}
+.bootstrap-timepicker.pull-right .bootstrap-timepicker-widget.dropdown-menu:before {
+  left: auto;
+  right: 12px;
+}
+.bootstrap-timepicker.pull-right .bootstrap-timepicker-widget.dropdown-menu:after {
+  left: auto;
+  right: 13px;
+}
+.bootstrap-timepicker .input-group-addon {
+  cursor: pointer;
+}
+.bootstrap-timepicker .input-group-addon i {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+}
+.bootstrap-timepicker-widget.dropdown-menu {
+  padding: 4px;
+}
+.bootstrap-timepicker-widget.dropdown-menu.open {
+  display: inline-block;
+}
+.bootstrap-timepicker-widget.dropdown-menu:before {
+  border-bottom: 7px solid rgba(0, 0, 0, 0.2);
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  content: "";
+  display: inline-block;
+  position: absolute;
+}
+.bootstrap-timepicker-widget.dropdown-menu:after {
+  border-bottom: 6px solid #FFFFFF;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  content: "";
+  display: inline-block;
+  position: absolute;
+}
+.bootstrap-timepicker-widget.timepicker-orient-left:before {
+  left: 6px;
+}
+.bootstrap-timepicker-widget.timepicker-orient-left:after {
+  left: 7px;
+}
+.bootstrap-timepicker-widget.timepicker-orient-right:before {
+  right: 6px;
+}
+.bootstrap-timepicker-widget.timepicker-orient-right:after {
+  right: 7px;
+}
+.bootstrap-timepicker-widget.timepicker-orient-top:before {
+  top: -7px;
+}
+.bootstrap-timepicker-widget.timepicker-orient-top:after {
+  top: -6px;
+}
+.bootstrap-timepicker-widget.timepicker-orient-bottom:before {
+  bottom: -7px;
+  border-bottom: 0;
+  border-top: 7px solid #999;
+}
+.bootstrap-timepicker-widget.timepicker-orient-bottom:after {
+  bottom: -6px;
+  border-bottom: 0;
+  border-top: 6px solid #ffffff;
+}
+.bootstrap-timepicker-widget a.btn,
+.bootstrap-timepicker-widget input {
+  border-radius: 4px;
+}
+.bootstrap-timepicker-widget table {
+  width: 100%;
+  margin: 0;
+}
+.bootstrap-timepicker-widget table td {
+  text-align: center;
+  height: 30px;
+  margin: 0;
+  padding: 2px;
+}
+.bootstrap-timepicker-widget table td:not(.separator) {
+  min-width: 30px;
+}
+.bootstrap-timepicker-widget table td span {
+  width: 100%;
+}
+.bootstrap-timepicker-widget table td a {
+  border: 1px transparent solid;
+  width: 100%;
+  display: inline-block;
+  margin: 0;
+  padding: 8px 0;
+  outline: 0;
+  color: #333;
+}
+.bootstrap-timepicker-widget table td a:hover {
+  text-decoration: none;
+  background-color: #eee;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+  border-color: #ddd;
+}
+.bootstrap-timepicker-widget table td a i {
+  margin-top: 2px;
+  font-size: 18px;
+}
+.bootstrap-timepicker-widget table td input {
+  width: 25px;
+  margin: 0;
+  text-align: center;
+}
+.bootstrap-timepicker-widget .modal-content {
+  padding: 4px;
+}
+@media (min-width: 767px) {
+  .bootstrap-timepicker-widget.modal {
+    width: 200px;
+    margin-left: -100px;
+  }
+}
+@media (max-width: 767px) {
+  .bootstrap-timepicker {
+    width: 100%;
+  }
+  .bootstrap-timepicker .dropdown-menu {
+    width: 100%;
+  }
+}

--- a/web/css/joindin.css
+++ b/web/css/joindin.css
@@ -107,6 +107,7 @@ h1 {
 h1, .h1, h2, .h2, h3, .h3 {
     margin-bottom: 5px;
     margin-top: 10px;
+    font-weight: normal;
 }
 
 h1, .h1 {

--- a/web/css/joindin.css
+++ b/web/css/joindin.css
@@ -674,3 +674,8 @@ a.talk.star {
 #loginheader {
     margin-bottom: 20px;
 }
+
+
+.top-spacer {
+    margin-top: 10px;
+}

--- a/web/css/joindin.css
+++ b/web/css/joindin.css
@@ -66,7 +66,6 @@ nav.navbar a.navbar-brand img {
     margin-top: 4px;
     padding-top: 1px;
     padding-bottom: 1px;
-    border-top: none;
     background-color: #FFFEDC;
 }
 .page-nav.admin .nav > li > a:hover, .page-nav.admin .nav > li > a:focus {

--- a/web/css/joindin.css
+++ b/web/css/joindin.css
@@ -83,6 +83,16 @@ form.navbar-form {
     color: #428bca;
 }
 
+.page-nav.admin .nav-pills > li.active > a, .page-nav.admin .nav-pills > li.active > a:focus {
+    font-weight: bold;
+    background-color: #FFFEDC;
+    color: #428bca;
+}
+.page-nav.admin .nav-pills > li.active > a:hover {
+    background-color: #FFFEDC;
+    color: #428bca;
+}
+
 h1 {
     border-bottom: 1px solid #d7dcdf;
     color: #000;

--- a/web/css/joindin.css
+++ b/web/css/joindin.css
@@ -679,3 +679,7 @@ a.talk.star {
 .top-spacer {
     margin-top: 10px;
 }
+
+form ul.speakers {
+    list-style-type: none;
+}

--- a/web/css/joindin.css
+++ b/web/css/joindin.css
@@ -52,6 +52,11 @@ nav.navbar a.navbar-brand img {
     margin-bottom: 0px
 }
 
+.page-nav.no-top-border {
+    border-top: none;
+    margin-top: 0;
+}
+
 .page-header {
   margin: 10px 0 20px;
   padding-bottom: 0;

--- a/web/js/bootstrap-timepicker.js
+++ b/web/js/bootstrap-timepicker.js
@@ -1,0 +1,1177 @@
+/*!
+ * Timepicker Component for Twitter Bootstrap
+ *
+ * Copyright 2013 Joris de Wit and bootstrap-timepicker contributors
+ *
+ * Contributors https://github.com/jdewit/bootstrap-timepicker/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function($, window, document) {
+  'use strict';
+
+  // TIMEPICKER PUBLIC CLASS DEFINITION
+  var Timepicker = function(element, options) {
+    this.widget = '';
+    this.$element = $(element);
+    this.defaultTime = options.defaultTime;
+    this.disableFocus = options.disableFocus;
+    this.disableMousewheel = options.disableMousewheel;
+    this.isOpen = options.isOpen;
+    this.minuteStep = options.minuteStep;
+    this.modalBackdrop = options.modalBackdrop;
+    this.orientation = options.orientation;
+    this.secondStep = options.secondStep;
+    this.snapToStep = options.snapToStep;
+    this.showInputs = options.showInputs;
+    this.showMeridian = options.showMeridian;
+    this.showSeconds = options.showSeconds;
+    this.template = options.template;
+    this.appendWidgetTo = options.appendWidgetTo;
+    this.showWidgetOnAddonClick = options.showWidgetOnAddonClick;
+    this.icons = options.icons;
+    this.maxHours = options.maxHours;
+    this.explicitMode = options.explicitMode; // If true 123 = 1:23, 12345 = 1:23:45, else invalid.
+
+    this.handleDocumentClick = function (e) {
+      var self = e.data.scope;
+      // This condition was inspired by bootstrap-datepicker.
+      // The element the timepicker is invoked on is the input but it has a sibling for addon/button.
+      if (!(self.$element.parent().find(e.target).length ||
+          self.$widget.is(e.target) ||
+          self.$widget.find(e.target).length)) {
+        self.hideWidget();
+      }
+    };
+
+    this._init();
+  };
+
+  Timepicker.prototype = {
+
+    constructor: Timepicker,
+    _init: function() {
+      var self = this;
+
+      if (this.showWidgetOnAddonClick && (this.$element.parent().hasClass('input-group') && this.$element.parent().hasClass('bootstrap-timepicker'))) {
+        this.$element.parent('.input-group.bootstrap-timepicker').find('.input-group-addon').on({
+          'click.timepicker': $.proxy(this.showWidget, this)
+        });
+        this.$element.on({
+          'focus.timepicker': $.proxy(this.highlightUnit, this),
+          'click.timepicker': $.proxy(this.highlightUnit, this),
+          'keydown.timepicker': $.proxy(this.elementKeydown, this),
+          'blur.timepicker': $.proxy(this.blurElement, this),
+          'mousewheel.timepicker DOMMouseScroll.timepicker': $.proxy(this.mousewheel, this)
+        });
+      } else {
+        if (this.template) {
+          this.$element.on({
+            'focus.timepicker': $.proxy(this.showWidget, this),
+            'click.timepicker': $.proxy(this.showWidget, this),
+            'blur.timepicker': $.proxy(this.blurElement, this),
+            'mousewheel.timepicker DOMMouseScroll.timepicker': $.proxy(this.mousewheel, this)
+          });
+        } else {
+          this.$element.on({
+            'focus.timepicker': $.proxy(this.highlightUnit, this),
+            'click.timepicker': $.proxy(this.highlightUnit, this),
+            'keydown.timepicker': $.proxy(this.elementKeydown, this),
+            'blur.timepicker': $.proxy(this.blurElement, this),
+            'mousewheel.timepicker DOMMouseScroll.timepicker': $.proxy(this.mousewheel, this)
+          });
+        }
+      }
+
+      if (this.template !== false) {
+        this.$widget = $(this.getTemplate()).on('click', $.proxy(this.widgetClick, this));
+      } else {
+        this.$widget = false;
+      }
+
+      if (this.showInputs && this.$widget !== false) {
+        this.$widget.find('input').each(function() {
+          $(this).on({
+            'click.timepicker': function() { $(this).select(); },
+            'keydown.timepicker': $.proxy(self.widgetKeydown, self),
+            'keyup.timepicker': $.proxy(self.widgetKeyup, self)
+          });
+        });
+      }
+
+      this.setDefaultTime(this.defaultTime);
+    },
+
+    blurElement: function() {
+      this.highlightedUnit = null;
+      this.updateFromElementVal();
+    },
+
+    clear: function() {
+      this.hour = '';
+      this.minute = '';
+      this.second = '';
+      this.meridian = '';
+
+      this.$element.val('');
+    },
+
+    decrementHour: function() {
+      if (this.showMeridian) {
+        if (this.hour === 1) {
+          this.hour = 12;
+        } else if (this.hour === 12) {
+          this.hour--;
+
+          return this.toggleMeridian();
+        } else if (this.hour === 0) {
+          this.hour = 11;
+
+          return this.toggleMeridian();
+        } else {
+          this.hour--;
+        }
+      } else {
+        if (this.hour <= 0) {
+          this.hour = this.maxHours - 1;
+        } else {
+          this.hour--;
+        }
+      }
+    },
+
+    decrementMinute: function(step) {
+      var newVal;
+
+      if (step) {
+        newVal = this.minute - step;
+      } else {
+        newVal = this.minute - this.minuteStep;
+      }
+
+      if (newVal < 0) {
+        this.decrementHour();
+        this.minute = newVal + 60;
+      } else {
+        this.minute = newVal;
+      }
+    },
+
+    decrementSecond: function() {
+      var newVal = this.second - this.secondStep;
+
+      if (newVal < 0) {
+        this.decrementMinute(true);
+        this.second = newVal + 60;
+      } else {
+        this.second = newVal;
+      }
+    },
+
+    elementKeydown: function(e) {
+      switch (e.which) {
+      case 9: //tab
+        if (e.shiftKey) {
+          if (this.highlightedUnit === 'hour') {
+            this.hideWidget();
+            break;
+          }
+          this.highlightPrevUnit();
+        } else if ((this.showMeridian && this.highlightedUnit === 'meridian') || (this.showSeconds && this.highlightedUnit === 'second') || (!this.showMeridian && !this.showSeconds && this.highlightedUnit ==='minute')) {
+          this.hideWidget();
+          break;
+        } else {
+          this.highlightNextUnit();
+        }
+        e.preventDefault();
+        this.updateFromElementVal();
+        break;
+      case 27: // escape
+        this.updateFromElementVal();
+        break;
+      case 37: // left arrow
+        e.preventDefault();
+        this.highlightPrevUnit();
+        this.updateFromElementVal();
+        break;
+      case 38: // up arrow
+        e.preventDefault();
+        switch (this.highlightedUnit) {
+        case 'hour':
+          this.incrementHour();
+          this.highlightHour();
+          break;
+        case 'minute':
+          this.incrementMinute();
+          this.highlightMinute();
+          break;
+        case 'second':
+          this.incrementSecond();
+          this.highlightSecond();
+          break;
+        case 'meridian':
+          this.toggleMeridian();
+          this.highlightMeridian();
+          break;
+        }
+        this.update();
+        break;
+      case 39: // right arrow
+        e.preventDefault();
+        this.highlightNextUnit();
+        this.updateFromElementVal();
+        break;
+      case 40: // down arrow
+        e.preventDefault();
+        switch (this.highlightedUnit) {
+        case 'hour':
+          this.decrementHour();
+          this.highlightHour();
+          break;
+        case 'minute':
+          this.decrementMinute();
+          this.highlightMinute();
+          break;
+        case 'second':
+          this.decrementSecond();
+          this.highlightSecond();
+          break;
+        case 'meridian':
+          this.toggleMeridian();
+          this.highlightMeridian();
+          break;
+        }
+
+        this.update();
+        break;
+      }
+    },
+
+    getCursorPosition: function() {
+      var input = this.$element.get(0);
+
+      if ('selectionStart' in input) {// Standard-compliant browsers
+
+        return input.selectionStart;
+      } else if (document.selection) {// IE fix
+        input.focus();
+        var sel = document.selection.createRange(),
+          selLen = document.selection.createRange().text.length;
+
+        sel.moveStart('character', - input.value.length);
+
+        return sel.text.length - selLen;
+      }
+    },
+
+    getTemplate: function() {
+      var template,
+        hourTemplate,
+        minuteTemplate,
+        secondTemplate,
+        meridianTemplate,
+        templateContent;
+
+      if (this.showInputs) {
+        hourTemplate = '<input type="text" class="bootstrap-timepicker-hour" maxlength="2"/>';
+        minuteTemplate = '<input type="text" class="bootstrap-timepicker-minute" maxlength="2"/>';
+        secondTemplate = '<input type="text" class="bootstrap-timepicker-second" maxlength="2"/>';
+        meridianTemplate = '<input type="text" class="bootstrap-timepicker-meridian" maxlength="2"/>';
+      } else {
+        hourTemplate = '<span class="bootstrap-timepicker-hour"></span>';
+        minuteTemplate = '<span class="bootstrap-timepicker-minute"></span>';
+        secondTemplate = '<span class="bootstrap-timepicker-second"></span>';
+        meridianTemplate = '<span class="bootstrap-timepicker-meridian"></span>';
+      }
+
+      templateContent = '<table>'+
+         '<tr>'+
+           '<td><a href="#" data-action="incrementHour"><span class="'+ this.icons.up +'"></span></a></td>'+
+           '<td class="separator">&nbsp;</td>'+
+           '<td><a href="#" data-action="incrementMinute"><span class="'+ this.icons.up +'"></span></a></td>'+
+           (this.showSeconds ?
+             '<td class="separator">&nbsp;</td>'+
+             '<td><a href="#" data-action="incrementSecond"><span class="'+ this.icons.up +'"></span></a></td>'
+           : '') +
+           (this.showMeridian ?
+             '<td class="separator">&nbsp;</td>'+
+             '<td class="meridian-column"><a href="#" data-action="toggleMeridian"><span class="'+ this.icons.up +'"></span></a></td>'
+           : '') +
+         '</tr>'+
+         '<tr>'+
+           '<td>'+ hourTemplate +'</td> '+
+           '<td class="separator">:</td>'+
+           '<td>'+ minuteTemplate +'</td> '+
+           (this.showSeconds ?
+            '<td class="separator">:</td>'+
+            '<td>'+ secondTemplate +'</td>'
+           : '') +
+           (this.showMeridian ?
+            '<td class="separator">&nbsp;</td>'+
+            '<td>'+ meridianTemplate +'</td>'
+           : '') +
+         '</tr>'+
+         '<tr>'+
+           '<td><a href="#" data-action="decrementHour"><span class="'+ this.icons.down +'"></span></a></td>'+
+           '<td class="separator"></td>'+
+           '<td><a href="#" data-action="decrementMinute"><span class="'+ this.icons.down +'"></span></a></td>'+
+           (this.showSeconds ?
+            '<td class="separator">&nbsp;</td>'+
+            '<td><a href="#" data-action="decrementSecond"><span class="'+ this.icons.down +'"></span></a></td>'
+           : '') +
+           (this.showMeridian ?
+            '<td class="separator">&nbsp;</td>'+
+            '<td><a href="#" data-action="toggleMeridian"><span class="'+ this.icons.down +'"></span></a></td>'
+           : '') +
+         '</tr>'+
+       '</table>';
+
+      switch(this.template) {
+      case 'modal':
+        template = '<div class="bootstrap-timepicker-widget modal hide fade in" data-backdrop="'+ (this.modalBackdrop ? 'true' : 'false') +'">'+
+          '<div class="modal-header">'+
+            '<a href="#" class="close" data-dismiss="modal">&times;</a>'+
+            '<h3>Pick a Time</h3>'+
+          '</div>'+
+          '<div class="modal-content">'+
+            templateContent +
+          '</div>'+
+          '<div class="modal-footer">'+
+            '<a href="#" class="btn btn-primary" data-dismiss="modal">OK</a>'+
+          '</div>'+
+        '</div>';
+        break;
+      case 'dropdown':
+        template = '<div class="bootstrap-timepicker-widget dropdown-menu">'+ templateContent +'</div>';
+        break;
+      }
+
+      return template;
+    },
+
+    getTime: function() {
+      if (this.hour === '') {
+        return '';
+      }
+
+      return this.hour + ':' + (this.minute.toString().length === 1 ? '0' + this.minute : this.minute) + (this.showSeconds ? ':' + (this.second.toString().length === 1 ? '0' + this.second : this.second) : '') + (this.showMeridian ? ' ' + this.meridian : '');
+    },
+
+    hideWidget: function() {
+      if (this.isOpen === false) {
+        return;
+      }
+
+      this.$element.trigger({
+        'type': 'hide.timepicker',
+        'time': {
+          'value': this.getTime(),
+          'hours': this.hour,
+          'minutes': this.minute,
+          'seconds': this.second,
+          'meridian': this.meridian
+        }
+      });
+
+      if (this.template === 'modal' && this.$widget.modal) {
+        this.$widget.modal('hide');
+      } else {
+        this.$widget.removeClass('open');
+      }
+
+      $(document).off('mousedown.timepicker, touchend.timepicker', this.handleDocumentClick);
+
+      this.isOpen = false;
+      // show/hide approach taken by datepicker
+      this.$widget.detach();
+    },
+
+    highlightUnit: function() {
+      this.position = this.getCursorPosition();
+      if (this.position >= 0 && this.position <= 2) {
+        this.highlightHour();
+      } else if (this.position >= 3 && this.position <= 5) {
+        this.highlightMinute();
+      } else if (this.position >= 6 && this.position <= 8) {
+        if (this.showSeconds) {
+          this.highlightSecond();
+        } else {
+          this.highlightMeridian();
+        }
+      } else if (this.position >= 9 && this.position <= 11) {
+        this.highlightMeridian();
+      }
+    },
+
+    highlightNextUnit: function() {
+      switch (this.highlightedUnit) {
+      case 'hour':
+        this.highlightMinute();
+        break;
+      case 'minute':
+        if (this.showSeconds) {
+          this.highlightSecond();
+        } else if (this.showMeridian){
+          this.highlightMeridian();
+        } else {
+          this.highlightHour();
+        }
+        break;
+      case 'second':
+        if (this.showMeridian) {
+          this.highlightMeridian();
+        } else {
+          this.highlightHour();
+        }
+        break;
+      case 'meridian':
+        this.highlightHour();
+        break;
+      }
+    },
+
+    highlightPrevUnit: function() {
+      switch (this.highlightedUnit) {
+      case 'hour':
+        if(this.showMeridian){
+          this.highlightMeridian();
+        } else if (this.showSeconds) {
+          this.highlightSecond();
+        } else {
+          this.highlightMinute();
+        }
+        break;
+      case 'minute':
+        this.highlightHour();
+        break;
+      case 'second':
+        this.highlightMinute();
+        break;
+      case 'meridian':
+        if (this.showSeconds) {
+          this.highlightSecond();
+        } else {
+          this.highlightMinute();
+        }
+        break;
+      }
+    },
+
+    highlightHour: function() {
+      var $element = this.$element.get(0),
+          self = this;
+
+      this.highlightedUnit = 'hour';
+
+      if ($element.setSelectionRange) {
+        setTimeout(function() {
+          if (self.hour < 10) {
+            $element.setSelectionRange(0,1);
+          } else {
+            $element.setSelectionRange(0,2);
+          }
+        }, 0);
+      }
+    },
+
+    highlightMinute: function() {
+      var $element = this.$element.get(0),
+          self = this;
+
+      this.highlightedUnit = 'minute';
+
+      if ($element.setSelectionRange) {
+        setTimeout(function() {
+          if (self.hour < 10) {
+            $element.setSelectionRange(2,4);
+          } else {
+            $element.setSelectionRange(3,5);
+          }
+        }, 0);
+      }
+    },
+
+    highlightSecond: function() {
+      var $element = this.$element.get(0),
+          self = this;
+
+      this.highlightedUnit = 'second';
+
+      if ($element.setSelectionRange) {
+        setTimeout(function() {
+          if (self.hour < 10) {
+            $element.setSelectionRange(5,7);
+          } else {
+            $element.setSelectionRange(6,8);
+          }
+        }, 0);
+      }
+    },
+
+    highlightMeridian: function() {
+      var $element = this.$element.get(0),
+          self = this;
+
+      this.highlightedUnit = 'meridian';
+
+      if ($element.setSelectionRange) {
+        if (this.showSeconds) {
+          setTimeout(function() {
+            if (self.hour < 10) {
+              $element.setSelectionRange(8,10);
+            } else {
+              $element.setSelectionRange(9,11);
+            }
+          }, 0);
+        } else {
+          setTimeout(function() {
+            if (self.hour < 10) {
+              $element.setSelectionRange(5,7);
+            } else {
+              $element.setSelectionRange(6,8);
+            }
+          }, 0);
+        }
+      }
+    },
+
+    incrementHour: function() {
+      if (this.showMeridian) {
+        if (this.hour === 11) {
+          this.hour++;
+          return this.toggleMeridian();
+        } else if (this.hour === 12) {
+          this.hour = 0;
+        }
+      }
+      if (this.hour === this.maxHours - 1) {
+        this.hour = 0;
+
+        return;
+      }
+      this.hour++;
+    },
+
+    incrementMinute: function(step) {
+      var newVal;
+
+      if (step) {
+        newVal = this.minute + step;
+      } else {
+        newVal = this.minute + this.minuteStep - (this.minute % this.minuteStep);
+      }
+
+      if (newVal > 59) {
+        this.incrementHour();
+        this.minute = newVal - 60;
+      } else {
+        this.minute = newVal;
+      }
+    },
+
+    incrementSecond: function() {
+      var newVal = this.second + this.secondStep - (this.second % this.secondStep);
+
+      if (newVal > 59) {
+        this.incrementMinute(true);
+        this.second = newVal - 60;
+      } else {
+        this.second = newVal;
+      }
+    },
+
+    mousewheel: function(e) {
+      if (this.disableMousewheel) {
+        return;
+      }
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      var delta = e.originalEvent.wheelDelta || -e.originalEvent.detail,
+          scrollTo = null;
+
+      if (e.type === 'mousewheel') {
+        scrollTo = (e.originalEvent.wheelDelta * -1);
+      }
+      else if (e.type === 'DOMMouseScroll') {
+        scrollTo = 40 * e.originalEvent.detail;
+      }
+
+      if (scrollTo) {
+        e.preventDefault();
+        $(this).scrollTop(scrollTo + $(this).scrollTop());
+      }
+
+      switch (this.highlightedUnit) {
+      case 'minute':
+        if (delta > 0) {
+          this.incrementMinute();
+        } else {
+          this.decrementMinute();
+        }
+        this.highlightMinute();
+        break;
+      case 'second':
+        if (delta > 0) {
+          this.incrementSecond();
+        } else {
+          this.decrementSecond();
+        }
+        this.highlightSecond();
+        break;
+      case 'meridian':
+        this.toggleMeridian();
+        this.highlightMeridian();
+        break;
+      default:
+        if (delta > 0) {
+          this.incrementHour();
+        } else {
+          this.decrementHour();
+        }
+        this.highlightHour();
+        break;
+      }
+
+      return false;
+    },
+
+    /**
+     * Given a segment value like 43, will round and snap the segment
+     * to the nearest "step", like 45 if step is 15. Segment will
+     * "overflow" to 0 if it's larger than 59 or would otherwise
+     * round up to 60.
+     */
+    changeToNearestStep: function (segment, step) {
+      if (segment % step === 0) {
+        return segment;
+      }
+      if (Math.round((segment % step) / step)) {
+        return (segment + (step - segment % step)) % 60;
+      } else {
+        return segment - segment % step;
+      }
+    },
+
+    // This method was adapted from bootstrap-datepicker.
+    place : function() {
+      if (this.isInline) {
+        return;
+      }
+      var widgetWidth = this.$widget.outerWidth(), widgetHeight = this.$widget.outerHeight(), visualPadding = 10, windowWidth =
+        $(window).width(), windowHeight = $(window).height(), scrollTop = $(window).scrollTop();
+
+      var zIndex = parseInt(this.$element.parents().filter(function() { return $(this).css('z-index') !== 'auto'; }).first().css('z-index'), 10) + 10;
+      var offset = this.component ? this.component.parent().offset() : this.$element.offset();
+      var height = this.component ? this.component.outerHeight(true) : this.$element.outerHeight(false);
+      var width = this.component ? this.component.outerWidth(true) : this.$element.outerWidth(false);
+      var left = offset.left, top = offset.top;
+
+      this.$widget.removeClass('timepicker-orient-top timepicker-orient-bottom timepicker-orient-right timepicker-orient-left');
+
+      if (this.orientation.x !== 'auto') {
+        this.$widget.addClass('timepicker-orient-' + this.orientation.x);
+        if (this.orientation.x === 'right') {
+          left -= widgetWidth - width;
+        }
+      } else{
+        // auto x orientation is best-placement: if it crosses a window edge, fudge it sideways
+        // Default to left
+        this.$widget.addClass('timepicker-orient-left');
+        if (offset.left < 0) {
+          left -= offset.left - visualPadding;
+        } else if (offset.left + widgetWidth > windowWidth) {
+          left = windowWidth - widgetWidth - visualPadding;
+        }
+      }
+      // auto y orientation is best-situation: top or bottom, no fudging, decision based on which shows more of the widget
+      var yorient = this.orientation.y, topOverflow, bottomOverflow;
+      if (yorient === 'auto') {
+        topOverflow = -scrollTop + offset.top - widgetHeight;
+        bottomOverflow = scrollTop + windowHeight - (offset.top + height + widgetHeight);
+        if (Math.max(topOverflow, bottomOverflow) === bottomOverflow) {
+          yorient = 'top';
+        } else {
+          yorient = 'bottom';
+        }
+      }
+      this.$widget.addClass('timepicker-orient-' + yorient);
+      if (yorient === 'top'){
+        top += height;
+      } else{
+        top -= widgetHeight + parseInt(this.$widget.css('padding-top'), 10);
+      }
+
+      this.$widget.css({
+        top : top,
+        left : left,
+        zIndex : zIndex
+      });
+    },
+
+    remove: function() {
+      $('document').off('.timepicker');
+      if (this.$widget) {
+        this.$widget.remove();
+      }
+      delete this.$element.data().timepicker;
+    },
+
+    setDefaultTime: function(defaultTime) {
+      if (!this.$element.val()) {
+        if (defaultTime === 'current') {
+          var dTime = new Date(),
+            hours = dTime.getHours(),
+            minutes = dTime.getMinutes(),
+            seconds = dTime.getSeconds(),
+            meridian = 'AM';
+
+          if (seconds !== 0) {
+            seconds = Math.ceil(dTime.getSeconds() / this.secondStep) * this.secondStep;
+            if (seconds === 60) {
+              minutes += 1;
+              seconds = 0;
+            }
+          }
+
+          if (minutes !== 0) {
+            minutes = Math.ceil(dTime.getMinutes() / this.minuteStep) * this.minuteStep;
+            if (minutes === 60) {
+              hours += 1;
+              minutes = 0;
+            }
+          }
+
+          if (this.showMeridian) {
+            if (hours === 0) {
+              hours = 12;
+            } else if (hours >= 12) {
+              if (hours > 12) {
+                hours = hours - 12;
+              }
+              meridian = 'PM';
+            } else {
+              meridian = 'AM';
+            }
+          }
+
+          this.hour = hours;
+          this.minute = minutes;
+          this.second = seconds;
+          this.meridian = meridian;
+
+          this.update();
+
+        } else if (defaultTime === false) {
+          this.hour = 0;
+          this.minute = 0;
+          this.second = 0;
+          this.meridian = 'AM';
+        } else {
+          this.setTime(defaultTime);
+        }
+      } else {
+        this.updateFromElementVal();
+      }
+    },
+
+    setTime: function(time, ignoreWidget) {
+      if (!time) {
+        this.clear();
+        return;
+      }
+
+      var timeMode,
+          timeArray,
+          hour,
+          minute,
+          second,
+          meridian;
+
+      if (typeof time === 'object' && time.getMonth){
+        // this is a date object
+        hour    = time.getHours();
+        minute  = time.getMinutes();
+        second  = time.getSeconds();
+
+        if (this.showMeridian){
+          meridian = 'AM';
+          if (hour > 12){
+            meridian = 'PM';
+            hour = hour % 12;
+          }
+
+          if (hour === 12){
+            meridian = 'PM';
+          }
+        }
+      } else {
+        timeMode = ((/a/i).test(time) ? 1 : 0) + ((/p/i).test(time) ? 2 : 0); // 0 = none, 1 = AM, 2 = PM, 3 = BOTH.
+        if (timeMode > 2) { // If both are present, fail.
+          this.clear();
+          return;
+        }
+
+        timeArray = time.replace(/[^0-9\:]/g, '').split(':');
+
+        hour = timeArray[0] ? timeArray[0].toString() : timeArray.toString();
+
+        if(this.explicitMode && hour.length > 2 && (hour.length % 2) !== 0 ) {
+          this.clear();
+          return;
+        }
+
+        minute = timeArray[1] ? timeArray[1].toString() : '';
+        second = timeArray[2] ? timeArray[2].toString() : '';
+
+        // adaptive time parsing
+        if (hour.length > 4) {
+          second = hour.slice(-2);
+          hour = hour.slice(0, -2);
+        }
+
+        if (hour.length > 2) {
+          minute = hour.slice(-2);
+          hour = hour.slice(0, -2);
+        }
+
+        if (minute.length > 2) {
+          second = minute.slice(-2);
+          minute = minute.slice(0, -2);
+        }
+
+        hour = parseInt(hour, 10);
+        minute = parseInt(minute, 10);
+        second = parseInt(second, 10);
+
+        if (isNaN(hour)) {
+          hour = 0;
+        }
+        if (isNaN(minute)) {
+          minute = 0;
+        }
+        if (isNaN(second)) {
+          second = 0;
+        }
+
+        // Adjust the time based upon unit boundary.
+        // NOTE: Negatives will never occur due to time.replace() above.
+        if (second > 59) {
+          second = 59;
+        }
+
+        if (minute > 59) {
+          minute = 59;
+        }
+
+        if (hour >= this.maxHours) {
+          // No day/date handling.
+          hour = this.maxHours - 1;
+        }
+
+        if (this.showMeridian) {
+          if (hour > 12) {
+            // Force PM.
+            timeMode = 2;
+            hour -= 12;
+          }
+          if (!timeMode) {
+            timeMode = 1;
+          }
+          if (hour === 0) {
+            hour = 12; // AM or PM, reset to 12.  0 AM = 12 AM.  0 PM = 12 PM, etc.
+          }
+          meridian = timeMode === 1 ? 'AM' : 'PM';
+        } else if (hour < 12 && timeMode === 2) {
+          hour += 12;
+        } else {
+          if (hour >= this.maxHours) {
+            hour = this.maxHours - 1;
+          } else if ((hour < 0) || (hour === 12 && timeMode === 1)){
+            hour = 0;
+          }
+        }
+      }
+
+      this.hour = hour;
+      if (this.snapToStep) {
+        this.minute = this.changeToNearestStep(minute, this.minuteStep);
+        this.second = this.changeToNearestStep(second, this.secondStep);
+      } else {
+        this.minute = minute;
+        this.second = second;
+      }
+      this.meridian = meridian;
+
+      this.update(ignoreWidget);
+    },
+
+    showWidget: function() {
+      if (this.isOpen) {
+        return;
+      }
+
+      if (this.$element.is(':disabled')) {
+        return;
+      }
+
+      // show/hide approach taken by datepicker
+      this.$widget.appendTo(this.appendWidgetTo);
+      $(document).on('mousedown.timepicker, touchend.timepicker', {scope: this}, this.handleDocumentClick);
+
+      this.$element.trigger({
+        'type': 'show.timepicker',
+        'time': {
+          'value': this.getTime(),
+          'hours': this.hour,
+          'minutes': this.minute,
+          'seconds': this.second,
+          'meridian': this.meridian
+        }
+      });
+
+      this.place();
+      if (this.disableFocus) {
+        this.$element.blur();
+      }
+
+      // widget shouldn't be empty on open
+      if (this.hour === '') {
+        if (this.defaultTime) {
+          this.setDefaultTime(this.defaultTime);
+        } else {
+          this.setTime('0:0:0');
+        }
+      }
+
+      if (this.template === 'modal' && this.$widget.modal) {
+        this.$widget.modal('show').on('hidden', $.proxy(this.hideWidget, this));
+      } else {
+        if (this.isOpen === false) {
+          this.$widget.addClass('open');
+        }
+      }
+
+      this.isOpen = true;
+    },
+
+    toggleMeridian: function() {
+      this.meridian = this.meridian === 'AM' ? 'PM' : 'AM';
+    },
+
+    update: function(ignoreWidget) {
+      this.updateElement();
+      if (!ignoreWidget) {
+        this.updateWidget();
+      }
+
+      this.$element.trigger({
+        'type': 'changeTime.timepicker',
+        'time': {
+          'value': this.getTime(),
+          'hours': this.hour,
+          'minutes': this.minute,
+          'seconds': this.second,
+          'meridian': this.meridian
+        }
+      });
+    },
+
+    updateElement: function() {
+      this.$element.val(this.getTime()).change();
+    },
+
+    updateFromElementVal: function() {
+      this.setTime(this.$element.val());
+    },
+
+    updateWidget: function() {
+      if (this.$widget === false) {
+        return;
+      }
+
+      var hour = this.hour,
+          minute = this.minute.toString().length === 1 ? '0' + this.minute : this.minute,
+          second = this.second.toString().length === 1 ? '0' + this.second : this.second;
+
+      if (this.showInputs) {
+        this.$widget.find('input.bootstrap-timepicker-hour').val(hour);
+        this.$widget.find('input.bootstrap-timepicker-minute').val(minute);
+
+        if (this.showSeconds) {
+          this.$widget.find('input.bootstrap-timepicker-second').val(second);
+        }
+        if (this.showMeridian) {
+          this.$widget.find('input.bootstrap-timepicker-meridian').val(this.meridian);
+        }
+      } else {
+        this.$widget.find('span.bootstrap-timepicker-hour').text(hour);
+        this.$widget.find('span.bootstrap-timepicker-minute').text(minute);
+
+        if (this.showSeconds) {
+          this.$widget.find('span.bootstrap-timepicker-second').text(second);
+        }
+        if (this.showMeridian) {
+          this.$widget.find('span.bootstrap-timepicker-meridian').text(this.meridian);
+        }
+      }
+    },
+
+    updateFromWidgetInputs: function() {
+      if (this.$widget === false) {
+        return;
+      }
+
+      var t = this.$widget.find('input.bootstrap-timepicker-hour').val() + ':' +
+              this.$widget.find('input.bootstrap-timepicker-minute').val() +
+              (this.showSeconds ? ':' + this.$widget.find('input.bootstrap-timepicker-second').val() : '') +
+              (this.showMeridian ? this.$widget.find('input.bootstrap-timepicker-meridian').val() : '')
+      ;
+
+      this.setTime(t, true);
+    },
+
+    widgetClick: function(e) {
+      e.stopPropagation();
+      e.preventDefault();
+
+      var $input = $(e.target),
+          action = $input.closest('a').data('action');
+
+      if (action) {
+        this[action]();
+      }
+      this.update();
+
+      if ($input.is('input')) {
+        $input.get(0).setSelectionRange(0,2);
+      }
+    },
+
+    widgetKeydown: function(e) {
+      var $input = $(e.target),
+          name = $input.attr('class').replace('bootstrap-timepicker-', '');
+
+      switch (e.which) {
+      case 9: //tab
+        if (e.shiftKey) {
+          if (name === 'hour') {
+            return this.hideWidget();
+          }
+        } else if ((this.showMeridian && name === 'meridian') || (this.showSeconds && name === 'second') || (!this.showMeridian && !this.showSeconds && name === 'minute')) {
+          return this.hideWidget();
+        }
+        break;
+      case 27: // escape
+        this.hideWidget();
+        break;
+      case 38: // up arrow
+        e.preventDefault();
+        switch (name) {
+        case 'hour':
+          this.incrementHour();
+          break;
+        case 'minute':
+          this.incrementMinute();
+          break;
+        case 'second':
+          this.incrementSecond();
+          break;
+        case 'meridian':
+          this.toggleMeridian();
+          break;
+        }
+        this.setTime(this.getTime());
+        $input.get(0).setSelectionRange(0,2);
+        break;
+      case 40: // down arrow
+        e.preventDefault();
+        switch (name) {
+        case 'hour':
+          this.decrementHour();
+          break;
+        case 'minute':
+          this.decrementMinute();
+          break;
+        case 'second':
+          this.decrementSecond();
+          break;
+        case 'meridian':
+          this.toggleMeridian();
+          break;
+        }
+        this.setTime(this.getTime());
+        $input.get(0).setSelectionRange(0,2);
+        break;
+      }
+    },
+
+    widgetKeyup: function(e) {
+      if ((e.which === 65) || (e.which === 77) || (e.which === 80) || (e.which === 46) || (e.which === 8) || (e.which >= 48 && e.which <= 57) || (e.which >= 96 && e.which <= 105)) {
+        this.updateFromWidgetInputs();
+      }
+    }
+  };
+
+  //TIMEPICKER PLUGIN DEFINITION
+  $.fn.timepicker = function(option) {
+    var args = Array.apply(null, arguments);
+    args.shift();
+    return this.each(function() {
+      var $this = $(this),
+        data = $this.data('timepicker'),
+        options = typeof option === 'object' && option;
+
+      if (!data) {
+        $this.data('timepicker', (data = new Timepicker(this, $.extend({}, $.fn.timepicker.defaults, options, $(this).data()))));
+      }
+
+      if (typeof option === 'string') {
+        data[option].apply(data, args);
+      }
+    });
+  };
+
+  $.fn.timepicker.defaults = {
+    defaultTime: 'current',
+    disableFocus: false,
+    disableMousewheel: false,
+    isOpen: false,
+    minuteStep: 15,
+    modalBackdrop: false,
+    orientation: { x: 'auto', y: 'auto'},
+    secondStep: 15,
+    snapToStep: false,
+    showSeconds: false,
+    showInputs: true,
+    showMeridian: true,
+    template: 'dropdown',
+    appendWidgetTo: 'body',
+    showWidgetOnAddonClick: true,
+    icons: {
+      up: 'glyphicon glyphicon-chevron-up',
+      down: 'glyphicon glyphicon-chevron-down'
+    },
+    maxHours: 24,
+    explicitMode: false
+  };
+
+  $.fn.timepicker.Constructor = Timepicker;
+
+  $(document).on(
+    'focus.timepicker.data-api click.timepicker.data-api',
+    '[data-provide="timepicker"]',
+    function(e){
+      var $this = $(this);
+      if ($this.data('timepicker')) {
+        return;
+      }
+      e.preventDefault();
+      // component click requires us to explicitly show it
+      $this.timepicker();
+    }
+  );
+
+})(jQuery, window, document);


### PR DESCRIPTION
Add the ability to add a talk to an event. 

This PR also implements the yellow admin bar for the event section as we now have three items for it and will have more, so this seemed a good time to to do it.

The ability to add speakers when adding the talk is also implemented. This works the same way as web1 and depends on [API PR #320](https://github.com/joindin/joindin-api/pull/320).

In order for the talk to be added to the selected track, [API PR #328](https://github.com/joindin/joindin-api/pull/328) is required.