### PR TITLE
Track administration

### DIFF
--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -54,6 +54,7 @@ class EventController extends BaseController
         $app->get('/event/:friendly_name/reported-comments', array($this, 'reportedComments'))->name("event-reported-comments");
         $app->post('/event/:friendly_name/moderate-comment', array($this, 'moderateComment'))->name("event-moderate-comment");
         $app->map('/event/:friendly_name/add-talk', array($this, 'addTalk'))->via('GET', 'POST')->name("event-add-talk");
+        $app->map('/event/:friendly_name/edit-tracks', array($this, 'editTracks'))->via('GET', 'POST')->name("event-edit-tracks");
     }
 
     public function index()
@@ -907,6 +908,73 @@ class EventController extends BaseController
                 'form' => $form->createView(),
             )
         );
+    }
+
+    /**
+     * Edit tracks for this event
+     *
+     * @param string $friendly_name
+     */
+    public function editTracks($friendly_name)
+    {
+        $eventApi = $this->getEventApi();
+        $event = $eventApi->getByFriendlyUrl($friendly_name);
+        if (!$event) {
+            return Slim::getInstance()->notFound();
+        }
+        if (!$event->getCanEdit()) {
+            $this->application->flash('error', "You do not have permission to do this.");
+            $this->redirectToDetailPage($event->getUrlFriendlyName());
+        }
+
+        $trackApi = $this->getTrackApi();
+        $tracks = $trackApi->getTracks($event->getTracksUri());
+        if ($tracks && $tracks['meta']['count']) {
+            $data['tracks'] = $tracks['tracks'];
+        } else {
+            $data['tracks'][] = [];
+        }
+
+        $factory = $this->application->formFactory;
+        $form = $factory->create(new TrackCollectionFormType(), $data);
+
+        $request = $this->application->request();
+        if ($request->isPost()) {
+            $form->submit($request->post($form->getName()));
+
+            if ($form->isValid()) {
+                $values = $form->getdata();
+
+                try {
+                    $eventTracksUri = $event->getTracksUri();
+                    foreach ($values['tracks'] as $item) {
+                        if ($item['uri']) {
+                            $trackApi->updateTrack($item['uri'], $item);
+                        } else {
+                            $trackApi->addTrack($eventTracksUri, $item);
+                        }
+                    }
+
+                    $this->application->flash('message', "Tracks updated");
+                    $this->application->redirect(
+                        $this->application->urlFor('event-edit-tracks', array('friendly_name' => $event->getUrlFriendlyName()))
+                    );
+                } catch (\Exception $e) {
+                    $form->adderror(
+                        new formError('An error occurred while adding this talk: ' . $e->getmessage())
+                    );
+                }
+            }
+        }
+
+        $this->render(
+            'Event/edit-tracks.html.twig',
+            array(
+                'event' => $event,
+                'form' => $form->createView(),
+            )
+        );
+
     }
 
     /**

--- a/app/src/Event/TrackApi.php
+++ b/app/src/Event/TrackApi.php
@@ -43,4 +43,52 @@ class TrackApi extends BaseApi
 
         return $tracks;
     }
+
+    /**
+     * Update a track
+     *
+     * @param  string $trackUri
+     * @param  array $data
+     */
+    public function updateTrack($trackUri, $data)
+    {
+        $params = [
+            'track_name' => $data['track_name'],
+            'track_description' => $data['track_description'],
+        ];
+
+        list($status, $result, $headers) = $this->apiPut($trackUri, $params);
+        if ($status == 204) {
+            return true;
+        }
+
+        $result = json_decode($result);
+        $message = $result[0];
+        
+        throw new \Exception("Failed: " . $message);
+    }
+
+    /**
+     * Add a track to an event's tracks collection
+     *
+     * @param  string $eventTracksUri
+     * @param  array $data
+     */
+    public function addTrack($eventTracksUri, $data)
+    {
+        $params = [
+            'track_name' => $data['track_name'],
+            'track_description' => $data['track_description'],
+        ];
+
+        list($status, $result, $headers) = $this->apiPost($eventTracksUri, $params);
+        if ($status == 201) {
+            return true;
+        }
+
+        $result = json_decode($result);
+        $message = $result[0];
+        
+        throw new \Exception("Failed: " . $message);
+    }
 }

--- a/app/src/Event/TrackApi.php
+++ b/app/src/Event/TrackApi.php
@@ -91,4 +91,23 @@ class TrackApi extends BaseApi
         
         throw new \Exception("Failed: " . $message);
     }
+
+    /**
+     * Delete a track
+     *
+     * @param  string $trackUri
+     * @param  array $data
+     */
+    public function deleteTrack($trackUri)
+    {
+        list($status, $result, $headers) = $this->apiDelete($trackUri);
+        if ($status == 204) {
+            return true;
+        }
+
+        $result = json_decode($result);
+        $message = $result[0];
+        
+        throw new \Exception("Failed to delete track: " . $message);
+    }
 }

--- a/app/src/Event/TrackCollectionFormType.php
+++ b/app/src/Event/TrackCollectionFormType.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Event;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Form used to render and validate the submission or editing of a track.
+ */
+class TrackCollectionFormType extends AbstractType
+{
+    /**
+     * Returns the name of this form type.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'track_collection';
+    }
+
+    /**
+     * Adds fields with their types and validation constraints to this definition.
+     *
+     * @param FormBuilderInterface $builder
+     * @param array                $options
+     *
+     * @return void
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(
+                'tracks',
+                'collection',
+                [
+                    'type' => new TrackFormType(),
+                    'allow_add' => true,
+                ]
+            )
+        ;
+    }
+}

--- a/app/src/Event/TrackCollectionFormType.php
+++ b/app/src/Event/TrackCollectionFormType.php
@@ -38,6 +38,7 @@ class TrackCollectionFormType extends AbstractType
                 [
                     'type' => new TrackFormType(),
                     'allow_add' => true,
+                    'allow_delete' => true,
                 ]
             )
         ;

--- a/app/src/Event/TrackFormType.php
+++ b/app/src/Event/TrackFormType.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Event;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Form used to render and validate the submission or editing of a track.
+ */
+class TrackFormType extends AbstractType
+{
+    /**
+     * Returns the name of this form type.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'track';
+    }
+
+    /**
+     * Adds fields with their types and validation constraints to this definition.
+     *
+     * @param FormBuilderInterface $builder
+     * @param array                $options
+     *
+     * @return void
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(
+                'uri',
+                'hidden',
+                [
+                    'required' => false,
+                ]
+            )
+            ->add(
+                'track_name',
+                'text',
+                [
+                    'constraints' => [new Assert\NotBlank()],
+                ]
+            )
+            ->add(
+                'track_description',
+                'textarea',
+                [
+                    'constraints' => [new Assert\NotBlank()],
+                    'attr'=> ['rows' => '2']
+                ]
+            )
+        ;
+    }
+}

--- a/app/templates/Event/_common/event_nav.html.twig
+++ b/app/templates/Event/_common/event_nav.html.twig
@@ -24,6 +24,9 @@
             <li class="{% if getCurrentRoute() == 'event-edit' %}active{% endif %}">
                 <a href="{{ urlFor('event-edit', {"friendly_name": event.getUrlFriendlyName}) }}">Edit</a>
             </li>
+            <li class="{% if getCurrentRoute() == 'event-edit-tracks' %}active{% endif %}">
+                <a href="{{ urlFor('event-edit-tracks', {"friendly_name": event.getUrlFriendlyName}) }}">Tracks</a>
+            </li>
             <li class="{% if getCurrentRoute() == 'event-add-talk' %}active{% endif %}">
                 <a href="{{ urlFor('event-add-talk', {"friendly_name": event.getUrlFriendlyName}) }}">Add talk</a>
             </li>

--- a/app/templates/Event/edit-tracks.html.twig
+++ b/app/templates/Event/edit-tracks.html.twig
@@ -67,6 +67,11 @@ jQuery(document).ready(function() {
     // Get the list that holds the collection of tags
     collectionHolder = $('ol.tracks');
 
+    // add a delete link to all of the existing tag form li elements
+    collectionHolder.find('li').each(function() {
+        addTrackFormDeleteLink($(this));
+    });
+
     // add the "add a tag" anchor and li to the tags ul
     collectionHolder.append(newLinkLi);
 
@@ -100,6 +105,19 @@ function addTrackForm($collectionHolder, $newLinkLi) {
     // Display the form in the page in an li, before the "Add a track" link li
     var $newFormLi = $('<li></li>').append(newForm);
     $newLinkLi.before($newFormLi);
+}
+
+function addTrackFormDeleteLink($tagFormLi) {
+    var $removeFormA = $('<a style="float: right" class="btn btn-default btn-xs" href="#">delete this track</a>');
+    $tagFormLi.prepend($removeFormA);
+
+    $removeFormA.on('click', function(e) {
+        // prevent the link from creating a "#" on the URL
+        e.preventDefault();
+
+        // remove the li for the tag form
+        $tagFormLi.remove();
+    });
 }
 </script>
 {% endblock %}

--- a/app/templates/Event/edit-tracks.html.twig
+++ b/app/templates/Event/edit-tracks.html.twig
@@ -1,0 +1,105 @@
+{% extends '/layout.html.twig' %}
+
+{% block title %}{{ event.getName }} Tracks - Joind.in{% endblock %}
+
+{% form_theme form _self %}
+    
+{% block body %}
+    {% include 'Event/_common/event_header.html.twig' %}
+    <h2>Tracks</h2>
+
+    {{ form_start(form, {'attr' : {'id' : 'event'} }) }}
+    {{ form_errors(form) }}
+{#
+        <div class="row">
+            <fieldset class="col-sm-12">
+                {{ form_row(form.track_name) }}
+            </fieldset>
+        </div>
+        <div class="row">
+            <fieldset class="col-sm-12">
+                {{ form_row(form.track_description) }}
+            </fieldset>
+        </div>
+ #}
+
+        <div class="row">
+            <fieldset class="col-sm-12">
+                <ol class="tracks" data-prototype="{{ form_widget(form.tracks.vars.prototype)|e }}">
+                    {% for track in form.tracks %}
+                        <li>
+                            {{ form_row(track.uri) }}
+                            {{ form_row(track.track_name) }}
+                            {{ form_row(track.track_description) }}
+                        </li>
+                    {% endfor %}
+                </ol>
+            </fieldset>
+        </div>
+ 
+        <div class="row">
+            <div class="col-sm-12">
+                <input type="submit" class="btn btn-primary pull-right" value="Update" />
+                <a href="{{ urlFor('event-detail', {friendly_name:event.urlFriendlyName}) }}" class="form-cancel pull-right">Cancel</a>
+            </div>
+        </div>
+        {{ form_end(form) }}
+
+{% endblock %}
+
+{% block extra_styles %}
+    <style>
+        label.required:after {
+            content: ' *'
+        }
+    </style>
+{% endblock %}
+
+{% block extra_javascript %}
+<script type="text/javascript">
+var collectionHolder;
+
+// setup an "add a track" link
+var addTrackLink = $('<a href="#" class="add_track_link btn btn-sm btn-default">Add a track</a>');
+var newLinkLi = $('<li></li>').append(addTrackLink);
+
+jQuery(document).ready(function() {
+    // Get the list that holds the collection of tags
+    collectionHolder = $('ol.tracks');
+
+    // add the "add a tag" anchor and li to the tags ul
+    collectionHolder.append(newLinkLi);
+
+    // count the current form inputs we have (e.g. 2), use that as the new
+    // index when inserting a new item (e.g. 2)
+    collectionHolder.data('index', collectionHolder.find(':input').length);
+
+    addTrackLink.on('click', function(e) {
+        // prevent the link from creating a "#" on the URL
+        e.preventDefault();
+
+        // add a new tag form (see next code block)
+        addTrackForm(collectionHolder, newLinkLi);
+    });
+});
+
+function addTrackForm($collectionHolder, $newLinkLi) {
+    // Get the data-prototype explained earlier
+    var prototype = $collectionHolder.data('prototype');
+
+    // get the new index
+    var index = $collectionHolder.data('index');
+
+    // Replace '__name__' in the prototype's HTML to
+    // instead be a number based on how many items we have
+    var newForm = prototype.replace(/__name__/g, index);
+
+    // increase the index with one for the next item
+    $collectionHolder.data('index', index + 1);
+
+    // Display the form in the page in an li, before the "Add a track" link li
+    var $newFormLi = $('<li></li>').append(newForm);
+    $newLinkLi.before($newFormLi);
+}
+</script>
+{% endblock %}

--- a/web/css/joindin.css
+++ b/web/css/joindin.css
@@ -683,3 +683,11 @@ a.talk.star {
 form ul.speakers {
     list-style-type: none;
 }
+
+form ol.tracks li {
+    margin-top: 20px;
+}
+form ol.tracks li:last-child {
+    list-style-type: none;
+    border-bottom: none;
+}


### PR DESCRIPTION
Ability to add, edit and delete tracks from an event.

This is implemented as a page containing a form with a collection of track form-types in it, so we can implement the functionality as a single page.

Requires PR [#338 (Add talk to an event)](https://github.com/joindin/joindin-web2/pull/338) as that one has the new admin nav bar in it.