### PR TITLE
Adding icon submission guidelines (solves JOINDIN-695)

### DIFF
--- a/app/templates/Event/_common/form.html.twig
+++ b/app/templates/Event/_common/form.html.twig
@@ -50,6 +50,7 @@
                 </div>
                 <div class="col-xs-7">
                     {{ form_row(form.new_icon) }}
+                    <p class="help-block">The image must be square.</p>
                 </div>
             </fieldset>
             {% endif %}

--- a/app/templates/Event/edit.html.twig
+++ b/app/templates/Event/edit.html.twig
@@ -40,6 +40,13 @@
                 </dd>
             </dl>
             <dl>
+                <dt>Icon</dt>
+                <dd>
+                    Please use a square image as an icon for your event; this is needed since the image is shown in a
+                    square space here on the site and in the mobile apps.
+                </dd>
+            </dl>
+            <dl>
                 <dt>Map</dt>
                 <dd>
                     Add the venue location to get a map on the website and apps so people can find you on the day.


### PR DESCRIPTION
As in title.

I've added a guideline in the sidebar as suggested in the issue, and also a short help message below the upload field in the form, so it's immediately visible, even on mobile.