### PR TITLE
Keep comment if no rating validation fails - solves JOINDIN-684

### DIFF
--- a/app/src/Talk/TalkController.php
+++ b/app/src/Talk/TalkController.php
@@ -145,12 +145,12 @@ class TalkController extends BaseController
         if ($comment == '' || $rating == 0) {
             $this->application->flash('error', 'Please provide a comment and rating');
 
-            if ($comment != ''){
+            if ($comment != '') {
                 //If the user provided a comment but no rating, send the comment back
-                $this->application->flash('comment',$comment);
-            }else{
+                $this->application->flash('comment', $comment);
+            } else {
                 //Otherwise, they provided a rating but no comment
-                $this->application->flash('rating',$rating);
+                $this->application->flash('rating', $rating);
             }
             $url .= '#add-comment';
             $this->application->redirect($url);
@@ -170,8 +170,8 @@ class TalkController extends BaseController
                     $this->application->flash('error', 'Duplicate comment.');
 
                     //Pass the comment and rating back to re-populate the form
-                    $this->application->flash('comment',$comment);
-                    $this->application->flash('rating',$rating);
+                    $this->application->flash('comment', $comment);
+                    $this->application->flash('rating', $rating);
 
                     $url .= '#add-comment';
 
@@ -182,8 +182,8 @@ class TalkController extends BaseController
                     $this->application->flash('error', 'Comment failed the spam check.');
 
                     //Pass the comment and rating back to re-populate the form
-                    $this->application->flash('comment',$comment);
-                    $this->application->flash('rating',$rating);
+                    $this->application->flash('comment', $comment);
+                    $this->application->flash('rating', $rating);
 
                     $url .= '#add-comment';
 

--- a/app/src/Talk/TalkController.php
+++ b/app/src/Talk/TalkController.php
@@ -144,6 +144,14 @@ class TalkController extends BaseController
 
         if ($comment == '' || $rating == 0) {
             $this->application->flash('error', 'Please provide a comment and rating');
+
+            if ($comment != ''){
+                //If the user provided a comment but no rating, send the comment back
+                $this->application->flash('comment',$comment);
+            }else{
+                //Otherwise, they provided a rating but no comment
+                $this->application->flash('rating',$rating);
+            }
             $url .= '#add-comment';
             $this->application->redirect($url);
         }
@@ -160,11 +168,25 @@ class TalkController extends BaseController
                 if (stripos($e->getMessage(), 'duplicate comment') !== false) {
                     // duplicate comment
                     $this->application->flash('error', 'Duplicate comment.');
+
+                    //Pass the comment and rating back to re-populate the form
+                    $this->application->flash('comment',$comment);
+                    $this->application->flash('rating',$rating);
+
+                    $url .= '#add-comment';
+
                     $this->application->redirect($url);
                 }
                 if (stripos($e->getMessage(), 'comment failed spam check') !== false) {
                     // spam comment
                     $this->application->flash('error', 'Comment failed the spam check.');
+
+                    //Pass the comment and rating back to re-populate the form
+                    $this->application->flash('comment',$comment);
+                    $this->application->flash('rating',$rating);
+
+                    $url .= '#add-comment';
+
                     $this->application->redirect($url);
                 }
                 throw $e;

--- a/app/templates/Talk/index.html.twig
+++ b/app/templates/Talk/index.html.twig
@@ -49,11 +49,11 @@
                                         <label for="rating">Rate the talk:</label>
                                         <select id="rating" name="rating">
                                             <option value="0"></option>
-                                            <option value="1">Needed more work</option>
-                                            <option value="2">Had potential</option>
-                                            <option value="3">Worth hearing</option>
-                                            <option value="4">Great info &amp; insight</option>
-                                            <option value="5">Brilliant!</option>
+                                            <option value="1"{% if (flash.getMessages.rating and flash.getMessages.rating == 1) %} selected="selected"{% endif %}>Needed more work</option>
+                                            <option value="2"{% if (flash.getMessages.rating and flash.getMessages.rating == 2) %} selected="selected"{% endif %}>Had potential</option>
+                                            <option value="3"{% if (flash.getMessages.rating and flash.getMessages.rating == 3) %} selected="selected"{% endif %}>Worth hearing</option>
+                                            <option value="4"{% if (flash.getMessages.rating and flash.getMessages.rating == 4) %} selected="selected"{% endif %}>Great info &amp; insight</option>
+                                            <option value="5"{% if (flash.getMessages.rating and flash.getMessages.rating == 5) %} selected="selected"{% endif %}>Brilliant!</option>
                                         </select>
                                         <br>
                                         <div class="rateit" id="rating_widget" data-rateit-backingfld="#rating" data-rateit-starwidth="23" data-rateit-starheight="21" data-rateit-resetable="false"></div>
@@ -62,7 +62,7 @@
                                 </div>
                                 <div class="form-group">
                                     <label for="comment">Your comment:</label>
-                                    <textarea id="comment" class="form-control" name="comment" rows="7"></textarea>
+                                    <textarea id="comment" class="form-control" name="comment" rows="7">{% if flash.getMessages.comment %}{{ flash.getMessages.comment }}{% endif %}</textarea>
                                 </div>
                                 <div class="form-group">
                                     <button type="submit" class="btn btn-primary">Submit comment</button>


### PR DESCRIPTION
Solves JOINDIN-684 by ensuring that the comment is re-populated into the form if no rating was provided, and vice-versa (maintains the rating if no comment was provided).

Also ensures that the correct anchor is returned in all error instances (Spam, Duplicated, etc.)