### PR TITLE
Add who's attending block to event details page - satisfies JOINDIN-621

### DIFF
--- a/app/src/Event/EventApi.php
+++ b/app/src/Event/EventApi.php
@@ -5,6 +5,7 @@ use Application\BaseApi;
 use Talk\TalkCommentEntity;
 use Talk\TalkCommentReportEntity;
 use User\UserApi;
+use User\UserEntity;
 
 class EventApi extends BaseApi
 {
@@ -206,6 +207,33 @@ class EventApi extends BaseApi
         }
 
         throw new \Exception("Failed to unmark you as attending: " . $result);
+    }
+
+
+    /**
+     * Get attendees for given event
+     * @param $attendees_uri
+     * @param bool $verbose
+     * @return UserEntity[]
+     */
+    public function getAttendees($attendees_uri, $limit = 0, $verbose = false)
+    {
+
+        $attendees_uri .= "?resultsperpage={$limit}";
+        if ($verbose) {
+            $attendees_uri = $attendees_uri . '&verbose=yes';
+        }
+
+
+        $attendees = (array)json_decode($this->apiGet($attendees_uri));
+
+        $attendeeData = array();
+
+        foreach ($attendees['users'] as $attendee) {
+            $attendeeData[] = new UserEntity($attendee);
+        }
+
+        return $attendeeData;
     }
 
     /**

--- a/app/src/Event/EventApi.php
+++ b/app/src/Event/EventApi.php
@@ -213,6 +213,7 @@ class EventApi extends BaseApi
     /**
      * Get attendees for given event
      * @param $attendees_uri
+     * @param $limit
      * @param bool $verbose
      * @return UserEntity[]
      */

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -192,7 +192,7 @@ class EventController extends BaseController
             . $this->application->urlFor('event-quicklink', array('stub' => $event->getStub()));
 
 
-        $attendees  = $eventApi->getAttendees($event->getAttendeesUri(),6);
+        $attendees  = $eventApi->getAttendees($event->getAttendeesUri(), 6);
 
         $this->render(
             'Event/details.html.twig',

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -29,6 +29,7 @@ class EventController extends BaseController
         $app->get('/event/callforpapers', array($this, 'callForPapers'))->name('event-call-for-papers');
         $app->get('/event/:friendly_name', array($this, 'eventDefault'))->name("event-default");
         $app->get('/event/:friendly_name/details', array($this, 'details'))->name("event-detail");
+        $app->get('/event/:friendly_name/attendees', array($this, 'attendees'))->name("event-attendees");
         $app->get('/event/:friendly_name/comments', array($this, 'comments'))->name("event-comments");
         $app->get('/event/:friendly_name/comments/:comment_hash/report', array($this, 'reportComment'))
             ->name("event-comments-reported");
@@ -182,6 +183,7 @@ class EventController extends BaseController
     {
         $eventApi = $this->getEventApi();
         $event    = $eventApi->getByFriendlyUrl($friendly_name);
+
         if (! $event) {
             return Slim::getInstance()->notFound();
         }
@@ -189,11 +191,36 @@ class EventController extends BaseController
         $quicklink = $this->application->request()->headers("host")
             . $this->application->urlFor('event-quicklink', array('stub' => $event->getStub()));
 
+
+        $attendees  = $eventApi->getAttendees($event->getAttendeesUri(),6);
+
         $this->render(
             'Event/details.html.twig',
             array(
                 'event' => $event,
                 'quicklink' => $quicklink,
+                'attendees' => $attendees
+            )
+        );
+    }
+
+    public function attendees($friendly_name){
+        $eventApi = $this->getEventApi();
+        $event    = $eventApi->getByFriendlyUrl($friendly_name);
+
+        if (! $event) {
+            return Slim::getInstance()->notFound();
+        }
+
+
+        $attendees  = $eventApi->getAttendees($event->getAttendeesUri());
+
+        $this->render(
+            'Event/_common/event_attendees.html.twig',
+            array(
+                'event'     => $event,
+                'fullList'  => true,
+                'attendees' => $attendees
             )
         );
     }

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -204,7 +204,8 @@ class EventController extends BaseController
         );
     }
 
-    public function attendees($friendly_name){
+    public function attendees($friendly_name)
+    {
         $eventApi = $this->getEventApi();
         $event    = $eventApi->getByFriendlyUrl($friendly_name);
 

--- a/app/src/Event/EventEntity.php
+++ b/app/src/Event/EventEntity.php
@@ -541,6 +541,11 @@ class EventEntity
         }
     }
 
+    public function getAttendeesUri(){
+        return $this->data->attendees_uri;
+
+    }
+
     public function getImagesUri()
     {
         return $this->data->images_uri;

--- a/app/src/Event/EventEntity.php
+++ b/app/src/Event/EventEntity.php
@@ -541,9 +541,9 @@ class EventEntity
         }
     }
 
-    public function getAttendeesUri(){
+    public function getAttendeesUri()
+    {
         return $this->data->attendees_uri;
-
     }
 
     public function getImagesUri()

--- a/app/templates/Event/_common/event_attendees.html.twig
+++ b/app/templates/Event/_common/event_attendees.html.twig
@@ -2,14 +2,14 @@
 <h3>Who's attending?</h3>
     <div class="row">
         {% for attendee in attendees %}
-            <div class="col col-sm-6 col-xs-4">
+            <div class="col col-sm-4 col-xs-3">
                 <img src="{{ gravatar(thisUser.getGravatarHash, 100) }}">
                 <div class="attendeeName"><a href="{{ urlFor('user-profile', {'username': attendee.username}) }}">{{ attendee.getFullName }}</a></div>
             </div>
         {% endfor %}
 
         {% if ((event.getAttendeeCount  > 6) and (not fullList)) %}
-            <p  class="text-center" >
+            <p  class="text-center col-xs-12" >
                 <a href="#" id="allAttendees">See all {{ event.getAttendeeCount }} attendees</a>
             </p>
         {% endif %}

--- a/app/templates/Event/_common/event_attendees.html.twig
+++ b/app/templates/Event/_common/event_attendees.html.twig
@@ -1,0 +1,17 @@
+{% if (event.getAttendeeCount  > 0) %}
+<h3>Who's attending?</h3>
+    <div class="row">
+        {% for attendee in attendees %}
+            <div class="col col-sm-6 col-xs-4">
+                <img src="{{ gravatar(thisUser.getGravatarHash, 100) }}">
+                <div class="attendeeName"><a href="{{ urlFor('user-profile', {'username': attendee.username}) }}">{{ attendee.getFullName }}</a></div>
+            </div>
+        {% endfor %}
+
+        {% if ((event.getAttendeeCount  > 6) and (not fullList)) %}
+            <p  class="text-center" >
+                <a href="#" id="allAttendees">See all {{ event.getAttendeeCount }} attendees</a>
+            </p>
+        {% endif %}
+    </div>
+{% endif %}

--- a/app/templates/Event/details.html.twig
+++ b/app/templates/Event/details.html.twig
@@ -75,6 +75,9 @@
 {% endblock %}
 
 {% block extraAside %}
+    <section class="event-attendees">
+        {% include 'Event/_common/event_attendees.html.twig' %}
+    </section>
 {% endblock %}
 
 {% block extra_meta %}
@@ -101,5 +104,17 @@
 
         L.marker([{{ event.getLatitude }}, {{ event.getLongitude }}]).addTo(map)
                 .bindPopup('<b>{{ location.finalName }}</b>');
+    </script>
+    <script>
+
+        jQuery(function($){
+            $("#allAttendees").click(function(ev){
+                ev.preventDefault();
+
+                var url = "{{ urlFor('event-attendees', {'friendly_name': event.getEventSlug}) }}";
+                $(".event-attendees").load(url);
+
+            })
+        })
     </script>
 {% endblock %}

--- a/web/css/joindin.css
+++ b/web/css/joindin.css
@@ -635,6 +635,7 @@ a.talk.star {
 .event-attendees .row .col .attendeeName {
     height:40px;
     overflow:hidden;
+    margin-top:5px;
 }
 
 .tags {

--- a/web/css/joindin.css
+++ b/web/css/joindin.css
@@ -624,6 +624,19 @@ a.talk.star {
     color: #777;
 }
 
+.event-attendees img {
+    max-width:100%
+}
+
+.event-attendees .row .col {
+    text-align:center;
+}
+
+.event-attendees .row .col .attendeeName {
+    height:40px;
+    overflow:hidden;
+}
+
 .tags {
     margin-bottom: 5px;
 }


### PR DESCRIPTION
Creates a basic sidebar block to show event attendees - shows 6 to start, with the rest loaded via AJAX on request (otherwise there could potentially be a pretty substantial performance hit for big events!)

The styling is fairly basic - it works and looks 'fine' I guess, but no doubt someone could pick it up and make it look better once it's in.