### PR TITLE
Ensure user is logged in for canEditTalk flag

### DIFF
--- a/app/src/Talk/TalkController.php
+++ b/app/src/Talk/TalkController.php
@@ -50,6 +50,11 @@ class TalkController extends BaseController
 
         $comments = $talkApi->getComments($talk->getCommentUri(), true, 0);
 
+        $canEditTalk = false;
+        if (isset($_SESSION['user'])) {
+            $canEditTalk = ($talk->isSpeaker($_SESSION['user']->getUri()) || $event->getCanEdit());
+        }
+
         $this->render(
             'Talk/index.html.twig',
             array(
@@ -57,7 +62,7 @@ class TalkController extends BaseController
                 'event' => $event,
                 'comments' => $comments,
                 'talkSlug' => $talkSlug,
-                'canEditTalk' => ($talk->isSpeaker($_SESSION['user']->getUri()) || $event->getCanEdit()),
+                'canEditTalk' => $canEditTalk,
             )
         );
     }


### PR DESCRIPTION
If the user is not logged in, don't check if the talk can be edited.

Fixes 500 error that's currently one live!