### PR TITLE
Composer improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,3 +49,7 @@ An example would be:
 ```
 JOINDIN-445 #close Fixed.
 ```
+
+## PHP Version
+
+The current PHP version for joind.in is PHP 5.6.

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
         }
     },
     "config": {
+        "platform": {
+            "php": "5.6.26"
+        },
         "preferred-install": "dist"
     },
     "minimum-stability": "stable",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,9 @@
             "User":        ["app/src/", "tests/"]
         }
     },
-    "preferred-install": "dist",
+    "config": {
+        "preferred-install": "dist"
+    },
     "minimum-stability": "stable",
     "require": {
         "predis/predis":         "~0.8",

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
         "symfony/validator":     "~2.5",
         "symfony/security-csrf": "~2.5",
         "symfony/twig-bridge":   "~2.5",
-        "org_heigl/daterange": "~1.1",
-        "guzzlehttp/guzzle": "^6.2.1",
-        "monolog/monolog": "^1.21"
+        "org_heigl/daterange":   "~1.1",
+        "guzzlehttp/guzzle":     "^6.2.1",
+        "monolog/monolog":       "^1.21"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "083534922877a82b22f4df8d390bd19c",
-    "content-hash": "a0f95876cb0d43a5e480cfd77a1a1a3a",
+    "hash": "e522a86bfda5b98e4eeb88cf56e1bc07",
+    "content-hash": "10678b4fd50e7f605c3908eb2b47a2be",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -1260,5 +1260,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "5.6.26"
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6ad18f6f75ff7f03356903a99a90faf2",
+    "hash": "083534922877a82b22f4df8d390bd19c",
     "content-hash": "a0f95876cb0d43a5e480cfd77a1a1a3a",
     "packages": [
         {

--- a/vendor/composer/ClassLoader.php
+++ b/vendor/composer/ClassLoader.php
@@ -53,8 +53,8 @@ class ClassLoader
 
     private $useIncludePath = false;
     private $classMap = array();
-
     private $classMapAuthoritative = false;
+    private $missingClasses = array();
 
     public function getPrefixes()
     {
@@ -322,20 +322,20 @@ class ClassLoader
         if (isset($this->classMap[$class])) {
             return $this->classMap[$class];
         }
-        if ($this->classMapAuthoritative) {
+        if ($this->classMapAuthoritative || isset($this->missingClasses[$class])) {
             return false;
         }
 
         $file = $this->findFileWithExtension($class, '.php');
 
         // Search for Hack files if we are running on HHVM
-        if ($file === null && defined('HHVM_VERSION')) {
+        if (false === $file && defined('HHVM_VERSION')) {
             $file = $this->findFileWithExtension($class, '.hh');
         }
 
-        if ($file === null) {
+        if (false === $file) {
             // Remember that this class does not exist.
-            return $this->classMap[$class] = false;
+            $this->missingClasses[$class] = true;
         }
 
         return $file;
@@ -399,6 +399,8 @@ class ClassLoader
         if ($this->useIncludePath && $file = stream_resolve_include_path($logicalPathPsr0)) {
             return $file;
         }
+
+        return false;
     }
 }
 


### PR DESCRIPTION
This started out as a search to figure out which version of PHP I should write against as a new joind.in dev. I first looked in the `CONTRIBUTING.md` file and didn't find anything. I then looked at the `composer.json` file and didn't see anything. However,`"preferred-install": "dist"` being a top-level setting in `composer.json` appeared to be incorrect, so I looked into where it needed to be: it needs to be in a config.

This PR attempts to fix both issues.

As a bonus, I guess, Composer 1.2.1 (latest version at this time) wanted to make some changes to the logic in Classloader. Those changes are part of this PR as well.