### PR TITLE
Fixes possibly endles while-loop in comment-field

### DIFF
--- a/app/templates/Talk/index.html.twig
+++ b/app/templates/Talk/index.html.twig
@@ -13,9 +13,8 @@
         });
         $('#rating_widget').bind('rated', function (event, value) { $("#rating_value").html($("#rating option[value='"+value+"']").text()) });
         $("#comment").keyup(function(e) {
-            while($(this).outerHeight() < this.scrollHeight + parseFloat($(this).css("borderTopWidth")) + parseFloat($(this).css("borderBottomWidth"))) {
-                $(this).height($(this).height()+1);
-            };
+            var offset = this.offsetHeight - this.clientHeight;
+            $(this).css('height', 'auto').css('height', this.scrollHeight + offset);
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
In some edge-cases it was possible that the while-loop that adapted the height of the comment field to the contents height went berserk and extended the height indefinitely. This commit changes that loop to one single function call so it will not be able to run indefinitely and leave the browser unresponsive.

Thanks to Elizabeth Smith for finding the issue and testing the fix.

Fixes JOINDIN-713