### PR TITLE
JOINDIN-698 #close

### DIFF
--- a/app/templates/Event/talk-comments.html.twig
+++ b/app/templates/Event/talk-comments.html.twig
@@ -15,7 +15,8 @@
         {% set talkSlug = talkSlugs[comment.getTalkUri()] %}
         {% include '_common/comment.html.twig' with {
             'showTalkTitle': true,
-            'talkLink': urlForTalk(event.getUrlFriendlyName(), talkSlug)
+            'talkLink': urlForTalk(event.getUrlFriendlyName(), talkSlug),
+            'talkSlug': talkSlug
         } %}
     {% endfor %}
 

--- a/app/templates/_common/comment.html.twig
+++ b/app/templates/_common/comment.html.twig
@@ -40,7 +40,7 @@
                                 <span class="hidden-xs">{% if comment.getCommentSource is not null %} (via {{ comment.getCommentSource }}){% endif %}</span>
                                 <br><br>
                                 {% if display_comment_report and user and user.uri != comment.getUserUri %}
-                                    <a href="/event/{{ event.getUrlFriendlyName }}{% if talk is not null %}/{{ talk.getUrlFriendlyTalkTitle }}{% endif %}/comments/{{ comment.getCommentHash }}/report">Report comment</a>
+                                    <a href="/event/{{ event.getUrlFriendlyName }}{% if talk is not null %}/{{ talk.getUrlFriendlyTalkTitle }}{% elseif talkSlug is not null %}/{{ talkSlug }}{% endif %}/comments/{{ comment.getCommentHash }}/report">Report comment</a>
                                 {% endif %}
                             </small>
                         </div>


### PR DESCRIPTION
 Alter twig templates to enable correct 'report comment' url to be used for the event/talk-comments view.
