### PR TITLE
Use abstract classes

### DIFF
--- a/app/src/Application/BaseApi.php
+++ b/app/src/Application/BaseApi.php
@@ -1,7 +1,7 @@
 <?php
 namespace Application;
 
-class BaseApi
+abstract class BaseApi
 {
     protected $baseApiUrl;
     protected $accessToken;

--- a/app/src/Application/BaseCommentEntity.php
+++ b/app/src/Application/BaseCommentEntity.php
@@ -1,0 +1,89 @@
+<?php
+namespace Application;
+
+abstract class BaseCommentEntity extends BaseEntity
+{
+    protected $commentUri;
+
+    public function getUserDisplayName()
+    {
+        if (!isset($this->data->user_display_name)) {
+            return null;
+        }
+
+        return $this->data->user_display_name;
+    }
+
+    public function getGravatarHash()
+    {
+        if (!isset($this->data->gravatar_hash)) {
+            return null;
+        }
+
+        return $this->data->gravatar_hash;
+    }
+
+    public function getRating()
+    {
+        if (!isset($this->data->rating)) {
+            return null;
+        }
+
+        return $this->data->rating;
+    }
+
+    public function getUserUri()
+    {
+        if (!isset($this->data->user_uri)) {
+            return null;
+        }
+
+        return $this->data->user_uri;
+    }
+
+    public function getReportedUri()
+    {
+        if (!isset($this->data->reported_uri)) {
+            return null;
+        }
+
+        return $this->data->reported_uri;
+    }
+
+    public function getCommentDate()
+    {
+        if (!isset($this->data->created_date)) {
+            return null;
+        }
+
+        return $this->data->created_date;
+    }
+
+    public function getComment()
+    {
+        if (!isset($this->data->comment)) {
+            return null;
+        }
+
+        return $this->data->comment;
+    }
+
+    public function getCommentSource()
+    {
+        if (!isset($this->data->source)) {
+            return null;
+        }
+
+        return $this->data->source;
+    }
+
+    public function getCommentHash()
+    {
+        if (!isset($this->commentUri)) {
+            return null;
+        }
+
+        $hash = md5($this->commentUri);
+        return (substr($hash, 0, 6));
+    }
+}

--- a/app/src/Application/BaseCommentEntity.php
+++ b/app/src/Application/BaseCommentEntity.php
@@ -1,9 +1,17 @@
 <?php
 namespace Application;
 
+use stdClass;
+
 abstract class BaseCommentEntity extends BaseEntity
 {
     protected $commentUri;
+
+    public function __construct(stdClass $data)
+    {
+        parent::__construct($data);
+        $this->commentUri = null;
+    }
 
     public function getUserDisplayName()
     {

--- a/app/src/Application/BaseCommentEntity.php
+++ b/app/src/Application/BaseCommentEntity.php
@@ -1,18 +1,8 @@
 <?php
 namespace Application;
 
-use stdClass;
-
 abstract class BaseCommentEntity extends BaseEntity
 {
-    protected $commentUri;
-
-    public function __construct(stdClass $data)
-    {
-        parent::__construct($data);
-        $this->commentUri = null;
-    }
-
     public function getUserDisplayName()
     {
         if (!isset($this->data->user_display_name)) {
@@ -85,13 +75,15 @@ abstract class BaseCommentEntity extends BaseEntity
         return $this->data->source;
     }
 
+    abstract public function getCommentUri();
+
     public function getCommentHash()
     {
-        if (!isset($this->commentUri)) {
+        if (empty($this->getCommentUri())) {
             return null;
         }
 
-        $hash = md5($this->commentUri);
+        $hash = md5($this->getCommentUri());
         return (substr($hash, 0, 6));
     }
 }

--- a/app/src/Application/BaseCommentReportingEntity.php
+++ b/app/src/Application/BaseCommentReportingEntity.php
@@ -1,9 +1,17 @@
 <?php
 namespace Application;
 
+use stdClass;
+
 abstract class BaseCommentReportingEntity extends BaseEntity
 {
     protected $comment;
+
+    public function __construct(stdClass $data)
+    {
+        parent::__construct($data);
+        $this->comment = null;
+    }
 
     public function getComment()
     {

--- a/app/src/Application/BaseCommentReportingEntity.php
+++ b/app/src/Application/BaseCommentReportingEntity.php
@@ -1,0 +1,22 @@
+<?php
+namespace Application;
+
+abstract class BaseCommentReportingEntity extends BaseEntity
+{
+    protected $comment;
+
+    public function getComment()
+    {
+        return $this->comment;
+    }
+
+    public function getReportingDate()
+    {
+        return $this->data->reporting_date;
+    }
+
+    public function getReportingUser()
+    {
+        return $this->data->reporting_user_username;
+    }
+}

--- a/app/src/Application/BaseController.php
+++ b/app/src/Application/BaseController.php
@@ -18,7 +18,10 @@ abstract class BaseController
         $this->defineRoutes($app);
         $this->cfg = $this->getConfig();
 
-        $this->accessToken = isset($_SESSION['access_token']) ? $_SESSION['access_token'] : null;
+        $this->accessToken = null;
+        if (isset($_SESSION['access_token'])) {
+            $this->accessToken = $_SESSION['access_token'];
+        }
     }
 
     private function getConfig()

--- a/app/src/Application/BaseController.php
+++ b/app/src/Application/BaseController.php
@@ -7,7 +7,7 @@ use Twig_Error_Runtime;
 abstract class BaseController
 {
     /** @var Slim */
-    protected $application = null;
+    protected $application;
 
     protected $accessToken;
     protected $cfg;

--- a/app/src/Application/BaseDb.php
+++ b/app/src/Application/BaseDb.php
@@ -1,9 +1,13 @@
 <?php
 namespace Application;
 
-class BaseDb
+abstract class BaseDb
 {
+    /** @var CacheService */
     protected $cache;
+
+    /** @var string */
+    protected $keyName;
 
     public function __construct(CacheService $cache)
     {

--- a/app/src/Application/BaseEntity.php
+++ b/app/src/Application/BaseEntity.php
@@ -1,15 +1,17 @@
 <?php
 namespace Application;
 
+use stdClass;
+
 abstract class BaseEntity
 {
     protected $data;
 
     /**
      * BaseEntity constructor.
-     * @param \stdClass $data Model data retrieved from API
+     * @param stdClass $data Model data retrieved from API
      */
-    public function __construct($data)
+    public function __construct(stdClass $data)
     {
         $this->data = $data;
     }

--- a/app/src/Application/BaseEntity.php
+++ b/app/src/Application/BaseEntity.php
@@ -1,0 +1,16 @@
+<?php
+namespace Application;
+
+abstract class BaseEntity
+{
+    protected $data;
+
+    /**
+     * BaseEntity constructor.
+     * @param \stdClass $data Model data retrieved from API
+     */
+    public function __construct($data)
+    {
+        $this->data = $data;
+    }
+}

--- a/app/src/Application/BaseEntity.php
+++ b/app/src/Application/BaseEntity.php
@@ -5,6 +5,7 @@ use stdClass;
 
 abstract class BaseEntity
 {
+    /** @var stdClass */
     protected $data;
 
     /**

--- a/app/src/Application/Config.php
+++ b/app/src/Application/Config.php
@@ -4,9 +4,9 @@ namespace Application;
 
 class Config implements \ArrayAccess
 {
-    protected $settings = array();
+    protected $settings;
 
-    public function __construct($settings)
+    public function __construct(array $settings = [])
     {
         $this->settings = $settings;
     }

--- a/app/src/Application/ContactApi.php
+++ b/app/src/Application/ContactApi.php
@@ -5,11 +5,6 @@ use Application\BaseApi;
 
 class ContactApi extends BaseApi
 {
-    public function __construct($config, $accessToken)
-    {
-        parent::__construct($config, $accessToken);
-    }
-
     public function contact($name, $email, $subject, $comment, $clientId, $clientSecret)
     {
 

--- a/app/src/Event/EventCommentEntity.php
+++ b/app/src/Event/EventCommentEntity.php
@@ -1,99 +1,13 @@
 <?php
 namespace Event;
 
-class EventCommentEntity
+use Application\BaseCommentEntity;
+
+class EventCommentEntity extends BaseCommentEntity
 {
-    private $data;
-
-    /**
-     * Create new EventCommentEntity
-     *
-     * @param Object $data Model data retrieved from API
-     */
-    public function __construct($data)
+    public function __construct(\stdClass $data)
     {
-        $this->data = $data;
-    }
-
-    public function getUserDisplayName()
-    {
-        if (!isset($this->data->user_display_name)) {
-            return null;
-        }
-
-        return $this->data->user_display_name;
-    }
-
-    public function getGravatarHash()
-    {
-        if (!isset($this->data->gravatar_hash)) {
-            return null;
-        }
-
-        return $this->data->gravatar_hash;
-    }
-
-    public function getCommentDate()
-    {
-        if (!isset($this->data->created_date)) {
-            return null;
-        }
-
-        return $this->data->created_date;
-    }
-
-    public function getComment()
-    {
-        if (!isset($this->data->comment)) {
-            return null;
-        }
-
-        return $this->data->comment;
-    }
-
-    public function getCommentSource()
-    {
-        if (!isset($this->data->source)) {
-            return null;
-        }
-
-        return $this->data->source;
-    }
-
-    public function getCommentHash()
-    {
-        if (!isset($this->data->comment_uri)) {
-            return null;
-        }
-
-        $hash = md5($this->data->comment_uri);
-        return (substr($hash, 0, 6));
-    }
-
-    public function getRating()
-    {
-        if (!isset($this->data->rating)) {
-            return null;
-        }
-
-        return $this->data->rating;
-    }
-
-    public function getReportedUri()
-    {
-        if (!isset($this->data->reported_uri)) {
-            return null;
-        }
-
-        return $this->data->reported_uri;
-    }
-
-    public function getUserUri()
-    {
-        if (!isset($this->data->user_uri)) {
-            return null;
-        }
-
-        return $this->data->user_uri;
+        parent::__construct($data);
+        $this->commentUri = isset($data->comment_uri) ? $data->comment_uri : null;
     }
 }

--- a/app/src/Event/EventCommentEntity.php
+++ b/app/src/Event/EventCommentEntity.php
@@ -2,10 +2,11 @@
 namespace Event;
 
 use Application\BaseCommentEntity;
+use stdClass;
 
 class EventCommentEntity extends BaseCommentEntity
 {
-    public function __construct(\stdClass $data)
+    public function __construct(stdClass $data)
     {
         parent::__construct($data);
         $this->commentUri = isset($data->comment_uri) ? $data->comment_uri : null;

--- a/app/src/Event/EventCommentEntity.php
+++ b/app/src/Event/EventCommentEntity.php
@@ -2,15 +2,15 @@
 namespace Event;
 
 use Application\BaseCommentEntity;
-use stdClass;
 
 class EventCommentEntity extends BaseCommentEntity
 {
-    public function __construct(stdClass $data)
+    public function getCommentUri()
     {
-        parent::__construct($data);
-        if (isset($this->data->comment_uri)) {
-            $this->commentUri = $this->data->comment_uri;
+        if (!isset($this->data->comment_uri)) {
+            return null;
         }
+
+        return $this->data->comment_uri;
     }
 }

--- a/app/src/Event/EventCommentEntity.php
+++ b/app/src/Event/EventCommentEntity.php
@@ -9,6 +9,8 @@ class EventCommentEntity extends BaseCommentEntity
     public function __construct(stdClass $data)
     {
         parent::__construct($data);
-        $this->commentUri = isset($data->comment_uri) ? $data->comment_uri : null;
+        if (isset($this->data->comment_uri)) {
+            $this->commentUri = $this->data->comment_uri;
+        }
     }
 }

--- a/app/src/Event/EventCommentReportEntity.php
+++ b/app/src/Event/EventCommentReportEntity.php
@@ -1,24 +1,24 @@
 <?php
 namespace Event;
 
-class EventCommentReportEntity
-{
-    private $data;
-    private $comment;
+use Application\BaseCommentReportingEntity;
 
+class EventCommentReportEntity extends BaseCommentReportingEntity
+{
     /**
      * Create new EventCommentReportEntity
      *
-     * @param Object $data Model data retrieved from API
+     * @param \stdClass $data Model data retrieved from API
      */
-    public function __construct($data)
+    public function __construct(\stdClass $data)
     {
+        parent::__construct($data);
+
         // should contain a comment
         if ($data->comment) {
             $this->comment = new EventCommentEntity($data->comment);
             unset($data->comment);
         }
-        $this->data = $data;
     }
 
     public function getComment()

--- a/app/src/Event/EventCommentReportEntity.php
+++ b/app/src/Event/EventCommentReportEntity.php
@@ -2,15 +2,16 @@
 namespace Event;
 
 use Application\BaseCommentReportingEntity;
+use stdClass;
 
 class EventCommentReportEntity extends BaseCommentReportingEntity
 {
     /**
      * Create new EventCommentReportEntity
      *
-     * @param \stdClass $data Model data retrieved from API
+     * @param stdClass $data Model data retrieved from API
      */
-    public function __construct(\stdClass $data)
+    public function __construct(stdClass $data)
     {
         parent::__construct($data);
 

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -30,7 +30,7 @@ class EventController extends BaseController
         $this->pendingItemsPerPage = 30;
     }
 
-    protected function defineRoutes(\Slim\Slim $app)
+    protected function defineRoutes(Slim $app)
     {
         // named routes first; should an event pick the same name then at least our actions take precedence
         $app->get('/event', array($this, 'index'))->name("events-index");
@@ -605,7 +605,7 @@ class EventController extends BaseController
         $eventApi = $this->getEventApi();
         $event = $eventApi->getEventById($eventId);
         if (!$event) {
-            return \Slim\Slim::getInstance()->notFound();
+            return Slim::getInstance()->notFound();
         }
 
         if ($extra && is_array($extra) && ($extra[0] == "talk_comments")) {

--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -20,8 +20,15 @@ use Language\LanguageApi;
 
 class EventController extends BaseController
 {
-    private $itemsPerPage = 10;
-    private $pendingItemsPerPage = 30;
+    private $itemsPerPage;
+    private $pendingItemsPerPage;
+
+    public function __construct(Slim $app)
+    {
+        parent::__construct($app);
+        $this->itemsPerPage = 10;
+        $this->pendingItemsPerPage = 30;
+    }
 
     protected function defineRoutes(\Slim\Slim $app)
     {

--- a/app/src/Event/EventDb.php
+++ b/app/src/Event/EventDb.php
@@ -2,10 +2,15 @@
 namespace Event;
 
 use Application\BaseDb;
+use Application\CacheService;
 
 class EventDb extends BaseDb
 {
-    protected $keyName = 'events';
+    public function __construct(CacheService $cache)
+    {
+        parent::__construct($cache);
+        $this->keyName = 'events';
+    }
 
     public function save(EventEntity $event)
     {

--- a/app/src/Event/EventEntity.php
+++ b/app/src/Event/EventEntity.php
@@ -1,22 +1,11 @@
 <?php
 namespace Event;
 
+use Application\BaseEntity;
 use DateTime;
 
-class EventEntity
+class EventEntity extends BaseEntity
 {
-    private $data;
-
-    /**
-     * Create new EventEntity
-     *
-     * @param Object $data Model data retrieved from API
-     */
-    public function __construct($data)
-    {
-        $this->data = $data;
-    }
-
     public function getName()
     {
         if (!isset($this->data->name)) {

--- a/app/src/Event/TrackApi.php
+++ b/app/src/Event/TrackApi.php
@@ -5,11 +5,6 @@ use Application\BaseApi;
 
 class TrackApi extends BaseApi
 {
-    public function __construct($config, $accessToken)
-    {
-        parent::__construct($config, $accessToken);
-    }
-
     /**
      * Retrieve list of tracks from the API
      *

--- a/app/src/Language/LanguageApi.php
+++ b/app/src/Language/LanguageApi.php
@@ -5,11 +5,6 @@ use Application\BaseApi;
 
 class LanguageApi extends BaseApi
 {
-    public function __construct($config, $accessToken)
-    {
-        parent::__construct($config, $accessToken);
-    }
-
     /**
      * Retrieve list of languages from the API
      *

--- a/app/src/Search/SearchController.php
+++ b/app/src/Search/SearchController.php
@@ -13,11 +13,10 @@ use User\UserApi;
 /**
  * Class SearchController
  * SearchController that will be combining API calls to search for events and talks
- * or to search for both seperately
+ * or to search for both separately
  */
 class SearchController extends BaseController
 {
-
     /**
      * @var integer The number of events / talks to fetch from the API
      */
@@ -26,7 +25,13 @@ class SearchController extends BaseController
     /**
      * @var integer The number of search results to show per page
      */
-    protected $itemsPerPage = 10;
+    protected $itemsPerPage;
+
+    public function __construct(Slim $app)
+    {
+        parent::__construct($app);
+        $this->itemsPerPage = 10;
+    }
 
     /**
      * @param \Slim $app

--- a/app/src/Search/SearchController.php
+++ b/app/src/Search/SearchController.php
@@ -5,6 +5,7 @@ use Application\BaseController;
 use Application\CacheService;
 use Event\EventApi;
 use Event\EventDb;
+use Slim\Slim;
 use Talk\TalkApi;
 use Talk\TalkDb;
 use User\UserDb;
@@ -34,9 +35,9 @@ class SearchController extends BaseController
     }
 
     /**
-     * @param \Slim $app
+     * @param Slim $app
      */
-    protected function defineRoutes(\Slim\Slim $app)
+    protected function defineRoutes(Slim $app)
     {
         $app->get('/search/events', array($this, 'searchEvents'))->name("search-events");
         $app->get('/search', array($this, 'search'))->name("search");

--- a/app/src/Talk/TalkCommentEntity.php
+++ b/app/src/Talk/TalkCommentEntity.php
@@ -1,36 +1,14 @@
 <?php
 namespace Talk;
 
-class TalkCommentEntity
+use Application\BaseCommentEntity;
+
+class TalkCommentEntity extends BaseCommentEntity
 {
-    private $data;
-
-    /**
-     * Create new TalkCommentEntity
-     *
-     * @param Object $data Model data retrieved from API
-     */
-    public function __construct($data)
+    public function __construct(\stdClass $data)
     {
-        $this->data = $data;
-    }
-
-    public function getRating()
-    {
-        if (!isset($this->data->rating)) {
-            return null;
-        }
-
-        return $this->data->rating;
-    }
-
-    public function getUserDisplayName()
-    {
-        if (!isset($this->data->user_display_name)) {
-            return null;
-        }
-
-        return $this->data->user_display_name;
+        parent::__construct($data);
+        $this->commentUri = isset($this->data->uri) ? $this->data->uri : null;
     }
 
     public function getUsername()
@@ -40,42 +18,6 @@ class TalkCommentEntity
         }
 
         return $this->data->username;
-    }
-
-    public function getGravatarHash()
-    {
-        if (!isset($this->data->gravatar_hash)) {
-            return null;
-        }
-
-        return $this->data->gravatar_hash;
-    }
-
-    public function getCommentDate()
-    {
-        if (!isset($this->data->created_date)) {
-            return null;
-        }
-
-        return $this->data->created_date;
-    }
-
-    public function getComment()
-    {
-        if (!isset($this->data->comment)) {
-            return null;
-        }
-
-        return $this->data->comment;
-    }
-
-    public function getCommentSource()
-    {
-        if (!isset($this->data->source)) {
-            return null;
-        }
-
-        return $this->data->source;
     }
 
     public function getTalkTitle()
@@ -94,34 +36,6 @@ class TalkCommentEntity
         }
 
         return $this->data->talk_uri;
-    }
-
-    public function getCommentHash()
-    {
-        if (!isset($this->data->uri)) {
-            return null;
-        }
-
-        $hash = md5($this->data->uri);
-        return (substr($hash, 0, 6));
-    }
-
-    public function getReportedUri()
-    {
-        if (!isset($this->data->reported_uri)) {
-            return null;
-        }
-
-        return $this->data->reported_uri;
-    }
-
-    public function getUserUri()
-    {
-        if (!isset($this->data->user_uri)) {
-            return null;
-        }
-
-        return $this->data->user_uri;
     }
 
     public function canRateTalk($user_uri)

--- a/app/src/Talk/TalkCommentEntity.php
+++ b/app/src/Talk/TalkCommentEntity.php
@@ -9,7 +9,9 @@ class TalkCommentEntity extends BaseCommentEntity
     public function __construct(stdClass $data)
     {
         parent::__construct($data);
-        $this->commentUri = isset($this->data->uri) ? $this->data->uri : null;
+        if (isset($this->data->uri)) {
+            $this->commentUri = $this->data->uri;
+        }
     }
 
     public function getUsername()

--- a/app/src/Talk/TalkCommentEntity.php
+++ b/app/src/Talk/TalkCommentEntity.php
@@ -2,10 +2,11 @@
 namespace Talk;
 
 use Application\BaseCommentEntity;
+use stdClass;
 
 class TalkCommentEntity extends BaseCommentEntity
 {
-    public function __construct(\stdClass $data)
+    public function __construct(stdClass $data)
     {
         parent::__construct($data);
         $this->commentUri = isset($this->data->uri) ? $this->data->uri : null;

--- a/app/src/Talk/TalkCommentEntity.php
+++ b/app/src/Talk/TalkCommentEntity.php
@@ -6,14 +6,6 @@ use stdClass;
 
 class TalkCommentEntity extends BaseCommentEntity
 {
-    public function __construct(stdClass $data)
-    {
-        parent::__construct($data);
-        if (isset($this->data->uri)) {
-            $this->commentUri = $this->data->uri;
-        }
-    }
-
     public function getUsername()
     {
         if (!isset($this->data->username)) {
@@ -39,6 +31,15 @@ class TalkCommentEntity extends BaseCommentEntity
         }
 
         return $this->data->talk_uri;
+    }
+
+    public function getCommentUri()
+    {
+        if (!isset($this->data->uri)) {
+            return null;
+        }
+
+        return $this->data->uri;
     }
 
     public function canRateTalk($user_uri)

--- a/app/src/Talk/TalkCommentReportEntity.php
+++ b/app/src/Talk/TalkCommentReportEntity.php
@@ -1,38 +1,23 @@
 <?php
 namespace Talk;
 
-class TalkCommentReportEntity
-{
-    private $data;
-    private $comment;
+use Application\BaseCommentReportingEntity;
 
+class TalkCommentReportEntity extends BaseCommentReportingEntity
+{
     /**
      * Create new TalkCommentReportEntity
      *
-     * @param Object $data Model data retrieved from API
+     * @param \stdClass $data Model data retrieved from API
      */
-    public function __construct($data)
+    public function __construct(\stdClass $data)
     {
+        parent::__construct($data);
+
         // should contain a comment
         if ($data->comment) {
             $this->comment = new TalkCommentEntity($data->comment);
             unset($data->comment);
         }
-        $this->data = $data;
-    }
-
-    public function getComment()
-    {
-        return $this->comment;
-    }
-
-    public function getReportingDate()
-    {
-        return $this->data->reporting_date;
-    }
-
-    public function getReportingUser()
-    {
-        return $this->data->reporting_user_username;
     }
 }

--- a/app/src/Talk/TalkCommentReportEntity.php
+++ b/app/src/Talk/TalkCommentReportEntity.php
@@ -2,15 +2,16 @@
 namespace Talk;
 
 use Application\BaseCommentReportingEntity;
+use stdClass;
 
 class TalkCommentReportEntity extends BaseCommentReportingEntity
 {
     /**
      * Create new TalkCommentReportEntity
      *
-     * @param \stdClass $data Model data retrieved from API
+     * @param stdClass $data Model data retrieved from API
      */
-    public function __construct(\stdClass $data)
+    public function __construct(stdClass $data)
     {
         parent::__construct($data);
 

--- a/app/src/Talk/TalkDb.php
+++ b/app/src/Talk/TalkDb.php
@@ -2,10 +2,15 @@
 namespace Talk;
 
 use Application\BaseDb;
+use Application\CacheService;
 
 class TalkDb extends BaseDb
 {
-    protected $keyName = 'talks';
+    public function __construct(CacheService $cache)
+    {
+        parent::__construct($cache);
+        $this->keyName = 'talks';
+    }
 
     public function getUriFor($slug, $eventUri)
     {

--- a/app/src/Talk/TalkEntity.php
+++ b/app/src/Talk/TalkEntity.php
@@ -1,23 +1,12 @@
 <?php
 namespace Talk;
 
+use Application\BaseEntity;
 use DateTime;
 use DateInterval;
 
-class TalkEntity
+class TalkEntity extends BaseEntity
 {
-    private $data;
-
-    /**
-     * Create new TalkEntity
-     *
-     * @param Object $data Model data retrieved from API
-     */
-    public function __construct($data)
-    {
-        $this->data = $data;
-    }
-
     /**
      * Is user a speaker on this talk?
      *

--- a/app/src/Talk/TalkTypeApi.php
+++ b/app/src/Talk/TalkTypeApi.php
@@ -5,11 +5,6 @@ use Application\BaseApi;
 
 class TalkTypeApi extends BaseApi
 {
-    public function __construct($config, $accessToken)
-    {
-        parent::__construct($config, $accessToken);
-    }
-
     /**
      * Retrieve list of talk types from the API
      *

--- a/app/src/User/UserDb.php
+++ b/app/src/User/UserDb.php
@@ -2,10 +2,15 @@
 namespace User;
 
 use Application\BaseDb;
+use Application\CacheService;
 
 class UserDb extends BaseDb
 {
-    protected $keyName = 'users';
+    public function __construct(CacheService $cache)
+    {
+        parent::__construct($cache);
+        $this->keyName = 'users';
+    }
 
     public function save(UserEntity $user)
     {

--- a/app/src/User/UserEntity.php
+++ b/app/src/User/UserEntity.php
@@ -2,20 +2,10 @@
 
 namespace User;
 
-class UserEntity
+use Application\BaseEntity;
+
+class UserEntity extends BaseEntity
 {
-    private $data;
-
-    /**
-     * Create new UserEntity
-     *
-     * @param stdclass $data Model data retrieved from API
-     */
-    public function __construct($data)
-    {
-        $this->data = $data;
-    }
-
     /**
      * Getter for username
      *


### PR DESCRIPTION
This is a code cleanup PR.

This formally declares two classes that were being used as abstract classes as abstract. This also extracts out some more abstract classes to make it easier to identify differences between like-classes.

I found a logic bug the EventScheduler while I was running through this, so I've also included its fix in this PR. If you'd prefer that fix be in a separate PR, let me know and I will split it out. (edit: split out to #375 )
