### PR TITLE
Fix error in checking for empty array

### DIFF
--- a/app/src/Event/EventScheduler.php
+++ b/app/src/Event/EventScheduler.php
@@ -130,7 +130,7 @@ class EventScheduler
 
             $tracks = $talk->getTracks();
 
-            if (is_array($tracks) && count($tracks > 0)) {
+            if (is_array($tracks) && !empty($tracks)) {
                 foreach ($tracks as $track) {
                     //obtain array of unique track names as array key
                     $tracksByDay[$date][$track->track_name] = true;


### PR DESCRIPTION
This fixes a logic error where the parentheses in an if-statement were misplaced. 

This replaces a `count` being greater than zero with a check for not- `empty`, since that's really what the intent is here.
