### PR TITLE
Removing the setting of $result in places where it isn't used

### DIFF
--- a/app/src/User/UserController.php
+++ b/app/src/User/UserController.php
@@ -173,9 +173,8 @@ class UserController extends BaseController
         $token = $request->get('token');
         $userApi = $this->getUserApi();
 
-        $result = false;
         try {
-            $result = $userApi->verify($token);
+            $userApi->verify($token);
             $this->application->flash('message', "Thank you for verifying your email address. You can now log in.");
         } catch (\Exception $e) {
             $this->application->flash('error', "Sorry, your verification link was invalid.");
@@ -202,7 +201,6 @@ class UserController extends BaseController
 
                 $userApi = $this->getUserApi();
 
-                $result = false;
                 try {
                     $result = $userApi->reverify($email);
                     if ($result) {
@@ -573,7 +571,6 @@ class UserController extends BaseController
 
                 $userApi = $this->getUserApi();
 
-                $result = false;
                 try {
                     $result = $userApi->usernameReminder($email);
                     if ($result) {
@@ -704,7 +701,6 @@ class UserController extends BaseController
 
                 $userApi = $this->getUserApi();
 
-                $result = false;
                 try {
                     $result = $userApi->passwordReset($username);
                     if ($result) {
@@ -752,7 +748,6 @@ class UserController extends BaseController
                 $values = $form->getData();
                 $userApi = $this->getUserApi();
 
-                $result = false;
                 try {
                     $result = $userApi->resetPassword($token, $values['password']);
                     if ($result) {


### PR DESCRIPTION
While researching another issue I noticed my PHPStorm complaining about unused variables. As it turns out, in quite a few places in the `UserController` the `$result` variable is being initialized with value `false`, but it is never used in the scope where it is defined. It is used later, but set to another value before usage. The initializing of `$result` to `false` therefore seems useless. In the spirit of leaving the code better than you found it, I decided to clean it up :) 