### PR TITLE
Adds QR-Code links to event- and talk-details

### DIFF
--- a/app/src/View/Functions.php
+++ b/app/src/View/Functions.php
@@ -164,4 +164,16 @@ function initialize(Twig_Environment $env, Slim $app)
             ['is_safe' => ['html']]
         )
     );
+
+    /**
+     * Create a link to download a QR-Code for the given URL
+     */
+    $env->addFunction(
+        new Twig_SimpleFunction('qrcode', function ($url) use ($app){
+            return sprintf(
+                'https://chart.googleapis.com/chart?cht=qr&chs=300x300&chl=%s&choe=UTF-8&chld=H',
+                urlencode($url)
+            );
+        })
+    );
 }

--- a/app/src/View/Functions.php
+++ b/app/src/View/Functions.php
@@ -169,7 +169,7 @@ function initialize(Twig_Environment $env, Slim $app)
      * Create a link to download a QR-Code for the given URL
      */
     $env->addFunction(
-        new Twig_SimpleFunction('qrcode', function ($url) use ($app){
+        new Twig_SimpleFunction('qrcode', function ($url) use ($app) {
             return sprintf(
                 'https://chart.googleapis.com/chart?cht=qr&chs=300x300&chl=%s&choe=UTF-8&chld=H',
                 urlencode($url)

--- a/app/templates/Event/details.html.twig
+++ b/app/templates/Event/details.html.twig
@@ -43,6 +43,7 @@
                     <br>
                     {% if event.stub %}
                         Short URL: <a href="{{ shortUrlForEvent(event.getStub) }}">{{ shortUrlForEvent(event.getStub) }}</a> <i class="fa fa-external-link-square"></i>
+                        <a class="qr-code" href="{{ qrcode(shortUrlForEvent(event.getStub)) }}">QR-Code</a>
                     {% endif %}
                     {% if event.getCfpStatus %}
                         <br>

--- a/app/templates/Talk/_common/talk_header.html.twig
+++ b/app/templates/Talk/_common/talk_header.html.twig
@@ -44,6 +44,7 @@
                         {% endif %}
                         <br>
                         Short URL: <a href="{{ shortUrlForTalk(talk.getStub) }}">{{ shortUrlForTalk(talk.getStub) }}</a>
+                        (<a class="qr-code" href="{{ qrcode(shortUrlForTalk(talk.getStub)) }}">QR-Code</a>)
                     </p>
                 </div>
                 <div class="col-xs-4 text-right">


### PR DESCRIPTION
This PR adds a link to an QR-Code to the event- and the talk-details. That way organizers and speakers can easily add a QR-Code to their slides for easier reference of the event or talk. That makes it
easier for attendees to find the talk or event and rate it.