### PR TITLE
Offers to resend welcome email to un verified user upon login attempt

### DIFF
--- a/app/src/User/AuthApi.php
+++ b/app/src/User/AuthApi.php
@@ -29,9 +29,7 @@ class AuthApi extends BaseApi
         if ($result) {
             $data = json_decode($result);
             if ($data) {
-                if (isset($data->access_token)) {
-                    return $data;
-                }
+                return $data;
             }
         }
         return false;

--- a/app/src/User/UserController.php
+++ b/app/src/User/UserController.php
@@ -872,8 +872,17 @@ class UserController extends BaseController
      */
     protected function handleLogin($result, $redirect = '')
     {
-        if (false === $result) {
-            $this->application->flash('error', "Failed to log in");
+        if (!is_object($result)) {
+            if (false === $result || $result[0] == 'Signin failed') {
+                $this->application->flash('error', "Failed to log in");
+            }
+            if ($result[0] == 'Not verified') {
+                $this->application->flash(
+                    'error',
+                    "User account not verified. <a href='/user/resend-verification'> 
+                        Click here</a> to resend welcome email.");
+            }
+
             if (empty($redirect)) {
                 $redirect = '/';
             }

--- a/app/src/User/UserController.php
+++ b/app/src/User/UserController.php
@@ -880,7 +880,8 @@ class UserController extends BaseController
                 $this->application->flash(
                     'error',
                     "User account not verified. <a href='/user/resend-verification'> 
-                        Click here</a> to resend welcome email.");
+                        Click here</a> to resend welcome email."
+                );
             }
 
             if (empty($redirect)) {

--- a/app/templates/_common/login.html.twig
+++ b/app/templates/_common/login.html.twig
@@ -3,7 +3,7 @@
         <div class="alert alert-success">{{flash.getMessages.message}}</div>
     {% endif %}
     {% if flash.getMessages.error %}
-        <div class="alert alert-danger">{{flash.getMessages.error}}</div>
+        <div class="alert alert-danger">{{flash.getMessages.error|raw}}</div>
     {% endif %}
     <div class="form-group">
         <label for="username">Username:</label>


### PR DESCRIPTION
Offers to resend welcome email to un verified user upon login attempt

If a user that is not verified tries to login then this change will show a flash message to that effect and provide a link which the user can click in order to have the validation email resent, this does not resend the email automatically, rather the user needs to enter their email address.  I personally think this is a more secure way to go about it rather than having a single link click send the email.

Relates to #JOINDIN-718