### PR TITLE
Added the CTA to submit an event to the homepage

### DIFF
--- a/app/templates/Application/index.html.twig
+++ b/app/templates/Application/index.html.twig
@@ -37,4 +37,13 @@
         <p>There are no events with an open call for papers.</p>
         {% endif %}
     </section>
+
+    <section>
+        <h3>Submit your event</h3>
+        <p>
+            Know of an event happening? Let us know! We love to get the word out about
+            events the community would be interested in and you can help us spread the word!
+        </p>
+        <a href="{{ urlFor('event-submit') }}" class="btn btn-primary col-xs-12">Submit</a>
+    </section>
 {% endblock %}


### PR DESCRIPTION
I was talking with @yourmark of the WordPress Meetup Enschede. He is not a very regular user of joind.in and he mentioned that he missed a CTA to add an event on the homepage. I decided it was a good idea to get less experienced used on board and create a PR. I hope you like this ;)