### PR TITLE
Enable the ability to update the access token

### DIFF
--- a/app/src/Application/BaseApi.php
+++ b/app/src/Application/BaseApi.php
@@ -203,4 +203,12 @@ abstract class BaseApi
 
         return $headers;
     }
+
+    /**
+     * @param $access_token
+     */
+    public function setAccessToken($accessToken)
+    {
+        $this->accessToken = $accessToken;
+    }
 }

--- a/app/src/User/UserController.php
+++ b/app/src/User/UserController.php
@@ -881,6 +881,9 @@ class UserController extends BaseController
 
         // now get users details
         $userApi = $this->getUserApi();
+
+        $userApi->setAccessToken($this->accessToken);
+
         $user = $userApi->getUser($result->user_uri);
         if ($user) {
             $_SESSION['user'] = $user;


### PR DESCRIPTION
Noticed today that I couldn't access the pending events page as an admin.

Having done some digging, it was to do with the move to using the Slim container (which is sort-of a registry).

When a user logs in, previously we were creating a new userApi object, which would thus inherit their new token - but this wasn't happening fetching the object from the container, and so the 'admin' property (which is only sent when requested with an admin token), wasn't coming through, and thus wasn't being added to the session.

Have added a method to the baseApi class to allow the access token to be re-set after the object as been created, and updated the handleLogin method to use this.

