### PR TITLE
Adds a link to the event-map

### DIFF
--- a/app/templates/Event/index.html.twig
+++ b/app/templates/Event/index.html.twig
@@ -48,4 +48,10 @@
             <p>There are no events with an open call for papers.</p>
         {% endif %}
     </section>
+    <section>
+        <h3>Looking for a nearby event?</h3>
+        <p>
+            Have a look at <a href="https://php.ug/#joindin">the map</a> to find what's near you.
+        </p>
+    </section>
 {% endblock %}


### PR DESCRIPTION
php.ug displays the upcoming events in a map-form so this commit adds a link to that map so that users can have a look at what events are near them…

This currently only shows events with a PHP-Tag. But's that an issue with php.ug that I will most likely remove within the next days…

This handles an idea that Juliette Reinders mentioned at PHP Southcoast. There's no ticket to it…