### PR TITLE
Title should be escaped, not raw

### DIFF
--- a/app/templates/Talk/_common/talk_header.html.twig
+++ b/app/templates/Talk/_common/talk_header.html.twig
@@ -2,7 +2,7 @@
     <div class="row event">
         <div class="col-xs-12 col-sm-12 title">
             <h1>
-                {{ talk.getTitle | raw }}
+                {{ talk.getTitle }}
                 {% if user %}
                     <span id="{{ event.getUrlFriendlyName }}/{{ talk.getUrlFriendlyTalkTitle }}" class="star-wrapper">
                         <a href="javascript:" class="talk star{% if talk.getStarred %} starred{% endif %}">{% if talk.starred %}&#10029;{% else %}&#10025;{% endif %}</a>

--- a/app/templates/Talk/index.html.twig
+++ b/app/templates/Talk/index.html.twig
@@ -1,6 +1,6 @@
 {% extends '/layout.html.twig' %}
 
-{% block title %}{{ talk.getTitle | raw }} - {{ event.getName }} - Joind.in{% endblock %}
+{% block title %}{{ talk.getTitle }} - {{ event.getName }} - Joind.in{% endblock %}
 
 {% block extra_javascript %}
     <script type="text/javascript">


### PR DESCRIPTION
We don't escape the title elsewhere, only do some filtering that strips away tags in the API writes. Therefore, escape it here so that values like `The wonder of <blink>` are allowed