### PR TITLE
Add target _blank to href tags for QR code links

### DIFF
--- a/app/templates/Event/details.html.twig
+++ b/app/templates/Event/details.html.twig
@@ -43,7 +43,7 @@
                     <br>
                     {% if event.stub %}
                         Short URL: <a href="{{ shortUrlForEvent(event.getStub) }}">{{ shortUrlForEvent(event.getStub) }}</a> <i class="fa fa-external-link-square"></i>
-                        <a class="qr-code" href="{{ qrcode(shortUrlForEvent(event.getStub)) }}" target="_blank">QR-Code</a>
+                        <a class="qr-code" href="{{ qrcode(shortUrlForEvent(event.getStub)) }}" target="_blank">QR-Code (opens in new window)</a>
                     {% endif %}
                     {% if event.getCfpStatus %}
                         <br>

--- a/app/templates/Event/details.html.twig
+++ b/app/templates/Event/details.html.twig
@@ -43,7 +43,7 @@
                     <br>
                     {% if event.stub %}
                         Short URL: <a href="{{ shortUrlForEvent(event.getStub) }}">{{ shortUrlForEvent(event.getStub) }}</a> <i class="fa fa-external-link-square"></i>
-                        <a class="qr-code" href="{{ qrcode(shortUrlForEvent(event.getStub)) }}">QR-Code</a>
+                        <a class="qr-code" href="{{ qrcode(shortUrlForEvent(event.getStub)) }}" target="_blank">QR-Code</a>
                     {% endif %}
                     {% if event.getCfpStatus %}
                         <br>

--- a/app/templates/Talk/_common/talk_header.html.twig
+++ b/app/templates/Talk/_common/talk_header.html.twig
@@ -60,7 +60,7 @@
 
                         <br>
                         Short URL: <a href="{{ shortUrlForTalk(talk.getStub) }}">{{ shortUrlForTalk(talk.getStub) }}</a>
-                        (<a class="qr-code" href="{{ qrcode(shortUrlForTalk(talk.getStub)) }}" target="_blank">QR-Code</a>)
+                        (<a class="qr-code" href="{{ qrcode(shortUrlForTalk(talk.getStub)) }}" target="_blank">QR-Code (opens in new window)</a>)
                     </p>
                 </div>
                 <div class="col-xs-4 text-right">

--- a/app/templates/Talk/_common/talk_header.html.twig
+++ b/app/templates/Talk/_common/talk_header.html.twig
@@ -60,7 +60,7 @@
 
                         <br>
                         Short URL: <a href="{{ shortUrlForTalk(talk.getStub) }}">{{ shortUrlForTalk(talk.getStub) }}</a>
-                        (<a class="qr-code" href="{{ qrcode(shortUrlForTalk(talk.getStub)) }}">QR-Code</a>)
+                        (<a class="qr-code" href="{{ qrcode(shortUrlForTalk(talk.getStub)) }}" target="_blank">QR-Code</a>)
                     </p>
                 </div>
                 <div class="col-xs-4 text-right">


### PR DESCRIPTION
I notice whist browsing the site that the QR-Code pages provide no way to intuitively go back to the site. For this reason I inadvertently closed the tab that I was using to browse the site instead of pressing back.

I feel this PR is an improvement to the current system as it adds the functionality to open the QR-Code's in new tabs.