### PR TITLE
Feature request: Include talk descriptions on talk list page #440

### DIFF
--- a/app/templates/Event/schedule-list.html.twig
+++ b/app/templates/Event/schedule-list.html.twig
@@ -29,6 +29,10 @@
                 <a class="btn btn-default {% if not starred_only %}active{% endif %}" href="{{current_url}}">All sessions</a>
                 <a class="btn btn-default {% if starred_only %}active{% endif %}" href="{{current_url}}/starred">Starred only</a>
             </div>
+            <div class="btn-group" role="group" aria-label="Style">
+                <a class="btn btn-default btn-talk-list-title active" href="#">Title</a>
+                <a class="btn btn-default btn-talk-list-title-description" href="#">Title &amp; Description</a>
+            </div>
         </div>
     </div>
 
@@ -55,12 +59,12 @@
                                     </a>
                                     {% endif %}
                                 </span>
-                                
+
                                 <span class="comment-count">
                                     <a href="{{ urlForTalk(event.getUrlFriendlyName, talk.getUrlFriendlyTalkTitle) }}">{{ talk.commentCount }}</a>
                                 </span>
                             </div>
-                            
+
                             {% if user %}
                             <div id="{{ event.getUrlFriendlyName }}/{{ talk.getUrlFriendlyTalkTitle }}" class="star-wrapper">
                                 <a href="javascript:" class="star{% if talk.starred %} starred{% endif %}">{% if talk.starred %}&#10029;{% else %}&#10025;{% endif %}</a>
@@ -91,6 +95,7 @@
                             {% if talk.duration %}
                                 <span class="lowlight">({{ prettyDuration(talk.duration)|replace({' ': '&nbsp;'})|raw }})</span>
                             {% endif %}
+                            <p class="toggle-talk-description">{{ talk.description }}</p>
                         </td>
                     </tr>
                 {% endif %}

--- a/web/css/joindin.css
+++ b/web/css/joindin.css
@@ -738,3 +738,7 @@ form ol.tracks li:last-child {
 .talk_media .form-group {
     display:inline-block;
 }
+.toggle-talk-description {
+    margin-top: 10px;
+    display: none;
+}

--- a/web/js/joindin.js
+++ b/web/js/joindin.js
@@ -173,4 +173,18 @@ $(function(){
             .addClass('panel-info')
             .addClass('comment-highlight');
     }
+
+    $("body").on("click", ".btn-talk-list-title", function (e) {
+        e.preventDefault();
+        $(".btn-talk-list-title-description").removeClass("active");
+        $(".btn-talk-list-title").addClass("active");
+        $(".toggle-talk-description").fadeOut("slow");
+    });
+
+    $("body").on("click", ".btn-talk-list-title-description", function (e) {
+        e.preventDefault();
+        $(".btn-talk-list-title-description").addClass("active");
+        $(".btn-talk-list-title").removeClass("active");
+        $(".toggle-talk-description").fadeIn("slow");
+    });
 });


### PR DESCRIPTION
Added a new button group for all lists (it does not apply to the grid as I thought it feels too crowdy). I choose the button group because I think is more expressive and integrates better with that "toolbar" of button groups. 

An alternative would be I think just a checkbox that would word something like "Include talks descriptions". 

What do you think?