### PR TITLE
Remove Pointless Cache Complexity

### DIFF
--- a/app/src/User/UserApi.php
+++ b/app/src/User/UserApi.php
@@ -145,12 +145,6 @@ class UserApi extends BaseApi
      */
     public function getUserByUsername($username)
     {
-        // do we already know this username's API URL?
-        $userInfo = $this->userDb->load('username', $username);
-        if ($userInfo) {
-            return $this->getUser($userInfo['uri']);
-        }
-
         // fetch via filtering the users collection
         $url = $this->baseApiUrl . '/v2.1/users';
         $result = $this->apiGet($url, ['username' => $username, 'verbose'=>'yes']);


### PR DESCRIPTION
Web2 has a cache system using redis that seems to be used for no real reason in this case. 

What is that advantage of looking up a cached API URI for a user and then using that uri to fetch the user from the API vs asking the API for a user matching a specific username? 

The only assumption (i have checked as far as I can) I am making here is that usernames are unique and that asking the API for a user by username will only return one result. This should not be an issue though as in the current code on a cache miss the user is fetched from the API by username, the first result used, and then the resulting user URI is cached to a key of the users username so in effect if multiple users were an issue then it would still be an issue.

I really see no need for this complexity in the code.