### PR TITLE
Allow us to tell QR coded links from normal ones

### DIFF
--- a/app/src/View/FunctionsExtension.php
+++ b/app/src/View/FunctionsExtension.php
@@ -185,7 +185,7 @@ final class FunctionsExtension extends Twig_Extension
             new Twig_SimpleFunction('qrcode', function ($url) {
                 return sprintf(
                     'https://chart.googleapis.com/chart?cht=qr&chs=300x300&chl=%s&choe=UTF-8&chld=H',
-                    urlencode($url)
+                    urlencode($url . '?qr')
                 );
             })
         ];

--- a/tests/View/Fixtures/functions/qrcode.test
+++ b/tests/View/Fixtures/functions/qrcode.test
@@ -7,4 +7,4 @@ return [
     'data1' => 'https://www.joind.in'
 ]
 --EXPECT--
-https://chart.googleapis.com/chart?cht=qr&amp;chs=300x300&amp;chl=https%3A%2F%2Fwww.joind.in&amp;choe=UTF-8&amp;chld=H
+https://chart.googleapis.com/chart?cht=qr&amp;chs=300x300&amp;chl=https%3A%2F%2Fwww.joind.in%3Fqr&amp;choe=UTF-8&amp;chld=H


### PR DESCRIPTION
This works because all of our links that are QR coded don't have query string parameters.

This way we can look at web server logs or similar to see how often people actually use QR codes.