### PR TITLE
Add honeypot for contact form

### DIFF
--- a/app/src/Application/ContactFormType.php
+++ b/app/src/Application/ContactFormType.php
@@ -88,6 +88,13 @@ class ContactFormType extends AbstractType
                     'constraints' => [new Assert\NotBlank()],
                 ]
             )
+            ->add(
+                'phone',
+                'text',
+                [
+                    'constraints' => [new Assert\Blank()],
+                ]
+            )
         ;
     }
 }

--- a/app/templates/Application/contact.html.twig
+++ b/app/templates/Application/contact.html.twig
@@ -36,6 +36,13 @@
             {{ form_row(form.comment) }}
         </fieldset>
     </div>
+    <div class="row phone">
+        <fieldset class="col-sm-12">
+            <p>Leave this field empty. We do not need your Phone-Number but bots will think so.</p>
+            <p>That way we can eliminate bots!</p>
+            {{ form_row(form.phone) }}
+        </fieldset>
+    </div>
     <div class="row">
         <div class="col-sm-12">
             <input type="submit" class="btn btn-primary pull-right" value="Submit" />

--- a/app/templates/Application/contact.html.twig
+++ b/app/templates/Application/contact.html.twig
@@ -38,8 +38,8 @@
     </div>
     <div class="row phone">
         <fieldset class="col-sm-12">
-            <p>Leave this field empty. We do not need your Phone-Number but bots will think so.</p>
-            <p>That way we can eliminate bots!</p>
+            <p>Leave this field empty. We do not need your phone number but bots will think we do.</p>
+            <p>Thanks for helping us keep this contact form bot-free!</p>
             {{ form_row(form.phone) }}
         </fieldset>
     </div>

--- a/web/css/joindin.css
+++ b/web/css/joindin.css
@@ -23,6 +23,10 @@ body {
     padding-bottom: 15px;
 }
 
+.row.phone {
+    display:none;
+}
+
 .navbar-default {
     background-image: none;
     background-color: white;


### PR DESCRIPTION
This adds a Form-Field that has to be empty. A so called HoneyPot. A
trap for bots that usually fill out every form field that seems
relevant. As the introduced field needs to be empty every
form-submission that contains that field will automatically be filtered
out as the form wasn't valid.