### PR TITLE
Fix legacy links

### DIFF
--- a/app/src/View/FunctionsExtension.php
+++ b/app/src/View/FunctionsExtension.php
@@ -30,7 +30,7 @@ final class FunctionsExtension extends Twig_Extension
 
         return [
             new Twig_SimpleFunction('urlFor', function ($routeName, $params = array()) use ($app) {
-                $url = $app->urlFor($routeName, $params);
+                $url = trim($app->urlFor($routeName, $params), '/');
 
                 return $url;
             }),

--- a/app/templates/Error/404.html.twig
+++ b/app/templates/Error/404.html.twig
@@ -6,7 +6,7 @@
     <h1 class="title">Page not found</h1>
     <p>Sorry, we can't find the page you tried to visit!</p>
 
-    <p>If you were expecting to see our old site, you can visit it at <a href="http://legacy.joind.in">http://legacy.joind.in</a></p>
+    <p>If you were expecting to see our old site, be informed that it is not available anymore.</p>
 
     <p>Please feel free to <a href="/contact">contact us</a> to tell us what went wrong</p>
 {%  endblock %}

--- a/app/templates/Error/404.html.twig
+++ b/app/templates/Error/404.html.twig
@@ -6,7 +6,7 @@
     <h1 class="title">Page not found</h1>
     <p>Sorry, we can't find the page you tried to visit!</p>
 
-    <p>If you were expecting to see our old site, be informed that it is not available anymore.</p>
+    <p>If you were expecting to see our old site, it is not available as of March 19th, 2019.</p>
 
     <p>Please feel free to <a href="/contact">contact us</a> to tell us what went wrong</p>
 {%  endblock %}


### PR DESCRIPTION
This fixes an issue that @exussum12 discovered.

The links to the Grid and the List-view where both broken due to a trailing slash. As we do not use trailing slashes anywhere I removed possibly trailing slashes via a `trim`-call.

Additionally the Error-Page still showed a link to the legacy-site that by now is not available anymore. So I removed it.