### PR TITLE
Don't trim leading slashes on links

### DIFF
--- a/app/src/View/FunctionsExtension.php
+++ b/app/src/View/FunctionsExtension.php
@@ -30,7 +30,7 @@ final class FunctionsExtension extends Twig_Extension
 
         return [
             new Twig_SimpleFunction('urlFor', function ($routeName, $params = array()) use ($app) {
-                $url = trim($app->urlFor($routeName, $params), '/');
+                $url = rtrim($app->urlFor($routeName, $params), '/');
 
                 return $url;
             }),


### PR DESCRIPTION
We don't want to suddenly turn all our links into relative links when
they were meant to be absolute.