### PR TITLE
Optimize Platform.sh-logo in footer

### DIFF
--- a/app/templates/layout.html.twig
+++ b/app/templates/layout.html.twig
@@ -95,7 +95,7 @@
 
                 <!-- Hidden on XS as it appears right above the footer, duplicating the info -->
                 <section class="text-center hidden-xs box sponsor">
-                    <svg width="173" height="36" viewBox="0 0 173 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <svg style="height: 1.3em;position: relative;top: 0.25em;" viewBox="0 0 173 36" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M172.62 0.848633H144.07V12.1206H172.62V0.848633Z" fill="#1A182A"></path>
                     <path d="M172.62 25.3789H144.07V29.2187H172.62V25.3789Z" fill="#1A182A"></path>
                     <path d="M172.62 15.7656H144.07V21.5494H172.62V15.7656Z" fill="#1A182A"></path>


### PR DESCRIPTION
The Platform.sh logo was a bit on the huge size in the footer-line. This commit fixes that by removing the fixed width and height that did not fit and replacing it with (currently hard-coded) style-information to make it more along the line of what the original CI of platform wanted it to look like.