### PR TITLE
Log exceptions via error_log()

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -81,6 +81,7 @@ $app->configureMode('development', function () use ($app) {
 
 // register error handlers
 $app->error(function (\Exception $e) use ($app) {
+    error_log(get_class($e) . ': ' . $e->getMessage() . " -- " . $e->getTraceAsString());
     $app->render('Error/error.html.twig', ['exception' => $e]);
 });
 

--- a/web/index.php
+++ b/web/index.php
@@ -17,7 +17,7 @@ session_set_cookie_params(60*60*24*7); // One week cookie
 session_cache_limiter(false);
 session_start();
 
-$config = array();
+$config = [];
 $configFile = realpath(__DIR__ . '/../config/config.php');
 if (is_readable($configFile)) {
     include $configFile;
@@ -32,9 +32,9 @@ $config['slim']['custom'] = new \Application\Config($config['slim']['custom']);
 $app = new \Slim\Slim(
     array_merge(
         $config['slim'],
-        array(
+        [
             'view' => new \Slim\Views\Twig(),
-        )
+        ]
     )
 );
 
@@ -48,15 +48,15 @@ $app->configureMode('development', function () use ($app) {
 // Pass the current mode to the template, so we can choose to show
 // certain things only if the app is in live/development mode
 $app->view()->appendData(
-    array('slim_mode' => $config['slim']['mode'])
+    ['slim_mode' => $config['slim']['mode']]
 );
 
 // Other variables needed by the main layout.html.twig template
 $app->view()->appendData(
-    array(
+    [
         'google_analytics_id' => $config['slim']['custom']['googleAnalyticsId'],
         'user' => (isset($_SESSION['user']) ? $_SESSION['user'] : false),
-    )
+    ]
 );
 
 // set Twig base folder, view folder and initialize Joindin filters


### PR DESCRIPTION
Looks like we were swallowing exceptions before?!?

This won't work in development mode, from what I can tell, because dev mode overrides how errors are displayed/handled. But we only really need it for live mode anyway since the idea is that if you're getting errors in dev mode you're somewhere you can look at the stack trace that pops up.