### PR TITLE
Align media form with displayed media link info

### DIFF
--- a/app/src/Talk/TalkMediaFormType.php
+++ b/app/src/Talk/TalkMediaFormType.php
@@ -32,10 +32,6 @@ class TalkMediaFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('url', 'text', [
-                'label' => false,
-                'required' => false,
-            ])
             ->add(
                 'type',
                 'choice',
@@ -50,6 +46,10 @@ class TalkMediaFormType extends AbstractType
                     'label' => false,
                 ]
             )
+            ->add('url', 'text', [
+                'label'    => false,
+                'required' => false,
+            ])
         ;
     }
 }


### PR DESCRIPTION
The issue was that if you have a media link and click ad media link
the form had a different order or type and uri.