### PR TITLE
Allow null-values for URL validation

### DIFF
--- a/app/src/Form/Constraint/UrlResolverConstraintValidator.php
+++ b/app/src/Form/Constraint/UrlResolverConstraintValidator.php
@@ -15,6 +15,10 @@ class UrlResolverConstraintValidator extends ConstraintValidator
             return;
         }
 
+        if ($value === null) {
+            return;
+        }
+
         $resolver = new UrlResolver();
         try {
             $resolver->resolve($value);

--- a/app/src/Form/Listener/GetResolvedUrlListener.php
+++ b/app/src/Form/Listener/GetResolvedUrlListener.php
@@ -37,6 +37,6 @@ class GetResolvedUrlListener implements EventSubscriberInterface
 
     public static function getSubscribedEvents()
     {
-        return array(FormEvents::SUBMIT => 'onSubmit');
+        return [FormEvents::SUBMIT => 'onSubmit'];
     }
 }

--- a/app/src/Form/Listener/GetResolvedUrlListener.php
+++ b/app/src/Form/Listener/GetResolvedUrlListener.php
@@ -13,7 +13,6 @@ use Form\Shared\UrlResolver;
  */
 class GetResolvedUrlListener implements EventSubscriberInterface
 {
-
     public function onSubmit(FormEvent $event)
     {
         $data = $event->getData();

--- a/app/src/Form/Listener/GetResolvedUrlListener.php
+++ b/app/src/Form/Listener/GetResolvedUrlListener.php
@@ -22,6 +22,10 @@ class GetResolvedUrlListener implements EventSubscriberInterface
             return;
         }
 
+        if ($data === null) {
+            return;
+        }
+
         $resolver = new UrlResolver();
         try {
             $redirectURL = $resolver->resolve($data);

--- a/tests/Form/Constraint/UrlResolverConstraintValidatorTest.php
+++ b/tests/Form/Constraint/UrlResolverConstraintValidatorTest.php
@@ -36,6 +36,8 @@ class UrlResolverConstraintValidatorTest extends TestCase
             'http://apple.de',
         ], [
             '',
+        ], [
+            null,
         ]];
     }
 

--- a/tests/Form/Listener/GetResolvedUrlListenerTest.php
+++ b/tests/Form/Listener/GetResolvedUrlListenerTest.php
@@ -65,6 +65,8 @@ class GetResolvedUrlListenerTest extends TestCase
             'http://example.unresolvable',
         ], [
             '',
+        ], [
+            null,
         ]];
     }
 }


### PR DESCRIPTION
This allows URLs that will be validated to also have a value of NULL instead of only allowing an empty string. Due to the way the values are passed into the validation a non-existent value will become a NULL-value and therefore failed before this fix.

Fixes #827