### PR TITLE
Tweaks for Event CSV importing

### DIFF
--- a/app/src/Event/EventController.php
+++ b/app/src/Event/EventController.php
@@ -1178,6 +1178,11 @@ class EventController extends BaseController
                     while (!feof($handle)) {
                         $talk = fgetcsv($handle);
                         $date_start = new \DateTimeImmutable(filter_var($talk[3], FILTER_SANITIZE_STRING).' '.filter_var($talk[4], FILTER_SANITIZE_STRING));
+                        $speakers = explode("|", $talk[2]);
+
+                        foreach ($speakers as $key => $speaker) {
+                            $speakers[$key] = filter_var($speaker, FILTER_SANITIZE_STRING);
+                        }
 
                         $talk_data = [
                             'talk_title' => filter_var($talk[0], FILTER_SANITIZE_STRING),
@@ -1186,7 +1191,7 @@ class EventController extends BaseController
                             'track' => filter_var($talk[8], FILTER_SANITIZE_STRING),
                             'language' => filter_var($talk[6], FILTER_SANITIZE_STRING),
                             'start_date' => $date_start->format('Y-m-d H:i'),
-                            'speakers' => [filter_var($talk[2], FILTER_SANITIZE_STRING)],
+                            'speakers' => $speakers,
                             'duration' => filter_var($talk[5], FILTER_SANITIZE_STRING),
                         ];
 

--- a/app/templates/Event/import-csv.html.twig
+++ b/app/templates/Event/import-csv.html.twig
@@ -26,7 +26,8 @@
                 <fieldset class="col-lg-12">
                     <legend>Event information</legend>
                     <div>
-                        Ensure your CSV file does not include a header row. You can download an example template
+                        Ensure your CSV file does not include a header row. You should also create any Tracks before you
+                        import your talks. You can download an example template
                         <a href="/files/EventScheduleCSVImportTemplate.csv" target="_blank">here</a>.
                     </div>
                     <fieldset class="col-offset-lg-6 col-lg-6 event">

--- a/web/files/EventScheduleCSVImportTemplate.csv
+++ b/web/files/EventScheduleCSVImportTemplate.csv
@@ -1,2 +1,2 @@
-Sample Talk,Description of Talk,Joe Ferguson,07/19/2019,02:00 PM,English - US,Talk,Track 1
-Sample Workshop,Description of Talk 2,Joe Ferguson,07/19/2019,09:00 AM,English - US,Workshop,Track 2
+Sample Talk,Description of Talk,Joe Ferguson,07/19/2019,02:00 PM,50,English - US,Talk,Track 1
+Sample Workshop,Description of Talk 2,Joe Ferguson|Second Speaker,07/19/2019,09:00 AM,45,English - US,Workshop,Track 2


### PR DESCRIPTION
* Fix CSV example which was missing `duration` field
* Add support for multiple speakers via `|` delimeter
* Add note in UI about tracks needing to exist before import
