### PR TITLE
Show anonymous gravatar for users with no username

### DIFF
--- a/app/templates/_common/comment.html.twig
+++ b/app/templates/_common/comment.html.twig
@@ -17,7 +17,11 @@
                 <div class="row">
                     <h3>
                         <div class="avatar pull-right">
-                            <img src="{{ gravatar(comment.getGravatarHash) }}">
+                            {% if comment.getUserDisplayName %}
+                                <img src="{{ gravatar(comment.getGravatarHash) }}">
+                            {%  else %}
+                                <img src="https://secure.gravatar.com/avatar/294de3557d9d00b3d2d8a1e6aab028cf?d=mm&s=40">
+                            {% endif %}
                         </div>
                         <div class="meta pull-right-sm pull-right-md pull-left-xs">
                             {% if comment.getUserDisplayName %}

--- a/app/templates/_common/comment.html.twig
+++ b/app/templates/_common/comment.html.twig
@@ -20,7 +20,7 @@
                             {% if comment.getUserDisplayName %}
                                 <img src="{{ gravatar(comment.getGravatarHash) }}">
                             {%  else %}
-                                <img src="https://secure.gravatar.com/avatar/294de3557d9d00b3d2d8a1e6aab028cf?d=mm&s=40">
+                                <img src="https://secure.gravatar.com/avatar/00000000000000000000000000000000?f=y&d=mp&s=40">
                             {% endif %}
                         </div>
                         <div class="meta pull-right-sm pull-right-md pull-left-xs">


### PR DESCRIPTION
Fix for #806

The comment in #806 is not really anonymous, at least not in any way I can see. The user that's on there has no username. So I'm not sure if that's something to do with account deletion, or whatever... But it has an email address. This fix should put the anonymous gravatar in place if the user who made a comment doesn't have a username. 

I haven't been able to find an example of any logged-in, but checked as anonymous that the site used to allow. If anyone has an example of one of those, it'd be pretty helpful.