### PR TITLE
Fix #832

### DIFF
--- a/app/templates/Talk/_common/talk_header.html.twig
+++ b/app/templates/Talk/_common/talk_header.html.twig
@@ -2,7 +2,7 @@
     <div class="row event">
         <div class="col-xs-12 col-sm-12 title">
             <h1>
-                {{ talk.getTitle | raw }}
+                {{ talk.getTitle }}
                 {% if user %}
                     <span id="{{ event.getUrlFriendlyName }}/{{ talk.getUrlFriendlyTalkTitle }}" class="star-wrapper">
                         <a href="javascript:" class="talk star{% if talk.getStarred %} starred{% endif %}">{% if talk.starred %}&#10029;{% else %}&#10025;{% endif %}</a>


### PR DESCRIPTION
Talk title is shown consistently in list and grid views, however there was a explicit raw filter in the talk info page. I don't know why it was there, but now it's gone.