### PR TITLE
Set the report link type to button

### DIFF
--- a/app/src/Apikey/ApikeyDeleteFormType.php
+++ b/app/src/Apikey/ApikeyDeleteFormType.php
@@ -12,7 +12,6 @@ use Event\EventEntity;
  */
 class ApikeyDeleteFormType extends AbstractType
 {
-
     /**
      * Returns the name of this form type.
      *

--- a/app/src/Client/ClientDeleteFormType.php
+++ b/app/src/Client/ClientDeleteFormType.php
@@ -12,7 +12,6 @@ use Event\EventEntity;
  */
 class ClientDeleteFormType extends AbstractType
 {
-
     /**
      * Returns the name of this form type.
      *

--- a/app/src/Client/ClientFormType.php
+++ b/app/src/Client/ClientFormType.php
@@ -12,7 +12,6 @@ use Event\EventEntity;
  */
 class ClientFormType extends AbstractType
 {
-
     /**
      * Returns the name of this form type.
      *

--- a/app/src/Talk/TalkDeleteFormType.php
+++ b/app/src/Talk/TalkDeleteFormType.php
@@ -12,7 +12,6 @@ use Event\EventEntity;
  */
 class TalkDeleteFormType extends AbstractType
 {
-
     /**
      * Returns the name of this form type.
      *

--- a/app/templates/_common/comment.html.twig
+++ b/app/templates/_common/comment.html.twig
@@ -44,7 +44,7 @@
                                 <span class="hidden-xs">{% if comment.getCommentSource is not null %} (via {{ comment.getCommentSource }}){% endif %}</span>
                                 <br><br>
                                 {% if display_comment_report and user and user.uri != comment.getUserUri %}
-                                    <a href="/event/{{ event.getUrlFriendlyName }}{% if talk is not null %}/{{ talk.getUrlFriendlyTalkTitle }}{% elseif talkSlug is not null %}/{{ talkSlug }}{% endif %}/comments/{{ comment.getCommentHash }}/report" onclick="return confirm('Are you sure you want to report this comment? This cannot be undone.');" >Report comment</a>
+                                    <a type="button" href="/event/{{ event.getUrlFriendlyName }}{% if talk is not null %}/{{ talk.getUrlFriendlyTalkTitle }}{% elseif talkSlug is not null %}/{{ talkSlug }}{% endif %}/comments/{{ comment.getCommentHash }}/report" onclick="return confirm('Are you sure you want to report this comment? This cannot be undone.');" >Report comment</a>
                                 {% endif %}
                             </small>
                         </div>

--- a/web/index.php
+++ b/web/index.php
@@ -114,7 +114,7 @@ $app->add(new Middleware\FormMiddleware($csrfSecret));
 $app->container->set('access_token', isset($_SESSION['access_token']) ? $_SESSION['access_token'] : null);
 
 $app->container->singleton(\Application\CacheService::class, function ($container) {
-    $redis = $container->settings['custom']['redis'];
+    $redis  = $container->settings['custom']['redis'];
     $prefix = $redis['options']['prefix'];
 
     if ($host = getenv('REDIS_HOST')) {


### PR DESCRIPTION
Working to debug why "Report comment" seems to be broken.

This PR is the next step. An attempt to set a HREF to a button.

Not able to reproduce locally but not in production.

Works locally:

![image](https://github.com/joindin/joindin-web2/assets/967362/4112c3bb-cbd1-41d3-bd97-9e35525c85e2)


But not in production:


![image](https://github.com/joindin/joindin-web2/assets/967362/b9110db6-73a4-4ac0-b9a8-db88b5c26b27)


Slack convo Debugging w/ @iansltx so far:

```
Joe: I'm testing if https://www.google.com/search?client=firefox-b-1-d&q=window.__cfRLUnblockHandlers is causing our "Report a Comment" to throw "method not found". Reporting comments is fine for me in local dev. But not in prod. Inspecting the HTML shows that __cfRL being injected into our buttons.

Ian: Got it. I can turn off Rocket Loader...and done. lmk if that fixes it

Joe: Nope, no luck. I guess we can turn it back on. I confirmed I didn't see that code in the HTML as I did before, but no change. Thanks for the help. 
```