### PR TITLE
fix: replace google api charts with quick chart

### DIFF
--- a/app/src/View/FunctionsExtension.php
+++ b/app/src/View/FunctionsExtension.php
@@ -157,7 +157,7 @@ final class FunctionsExtension extends Twig_Extension
              */
             new Twig_SimpleFunction('qrcode', function ($url) {
                 return sprintf(
-                    'https://chart.googleapis.com/chart?cht=qr&chs=300x300&chl=%s&choe=UTF-8&chld=H',
+                    'https://quickchart.io/chart?cht=qr&chs=300x300&chl=%s&choe=UTF-8&chld=H',
                     urlencode($url . '?qr')
                 );
             })

--- a/tests/View/Fixtures/functions/qrcode.test
+++ b/tests/View/Fixtures/functions/qrcode.test
@@ -7,4 +7,4 @@ return [
     'data1' => 'https://www.joind.in'
 ]
 --EXPECT--
-https://chart.googleapis.com/chart?cht=qr&amp;chs=300x300&amp;chl=https%3A%2F%2Fwww.joind.in%3Fqr&amp;choe=UTF-8&amp;chld=H
+https://quickchart.io/chart?cht=qr&amp;chs=300x300&amp;chl=https%3A%2F%2Fwww.joind.in%3Fqr&amp;choe=UTF-8&amp;chld=H


### PR DESCRIPTION
Fixes https://github.com/joindin/joindin-web2/issues/924