### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,4 +34,4 @@ The current PHP version for joind.in is PHP 5.6.
 
 ## Code Style
 
-All PHP code follows [psr-2](http://www.php-fig.org/psr/psr-2/). One way to help ensure that your submitted code is PSR-2 is to run [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer) against PSR-2 and the [.editorconfig](http://editorconfig.org/) plugin for your editor before submitting.
+All PHP code follows [psr-2](http://www.php-fig.org/psr/psr-2/). One way to help ensure that your submitted code is PSR-2 is to run [PHP Code Sniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) against PSR-2 and the [.editorconfig](http://editorconfig.org/) plugin for your editor before submitting.


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932